### PR TITLE
Add empty setup.py to counter dependabot bug.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+# This empty setup.py is just here for Dependabot to work
+# (https://github.com/dependabot/dependabot-core/issues/4230)
+# What you're looking for is most likely in pyproject.toml.


### PR DESCRIPTION
Call it a hunch, but dependabot is failing on this repo with this crash log:

```
/setup.cfg?ref=3bcf84f4ef65cab5cbda623101e8468a2ebf2a98
  proxy | 2021/09/27 21:19:51 [028] * authenticating github api request
  proxy | 2021/09/27 21:19:51 [028] 200 https://api.github.com:443/repos/procrastinate-org/procrastinate/contents/setup.cfg?ref=3bcf84f4ef65cab5cbda623101e8468a2ebf2a98
  proxy | 2021/09/27 21:19:51 [030] GET https://api.github.com:443/repos/procrastinate-org/procrastinate/contents/setup.py?ref=3bcf84f4ef65cab5cbda623101e8468a2ebf2a98
  proxy | 2021/09/27 21:19:51 [030] * authenticating github api request
  proxy | 2021/09/27 21:19:51 [030] 404 https://api.github.com:443/repos/procrastinate-org/procrastinate/contents/setup.py?ref=3bcf84f4ef65cab5cbda623101e8468a2ebf2a98
updater | ERROR <job_213615061> Error during file fetching; aborting
updater | INFO <job_213615061> Finished job processing
```

and I'm convinced that if this setup.py existed, then dependabot would work. Worth trying, we'll revert if it doesn't fix.

### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
