### PR TITLE
Remove support for Python 3.6, add support for 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - python_version: 3.6
+          - python_version: "3.7"
             script: tests
-          - python_version: 3.7
+          - python_version: "3.8"
             script: tests
-          - python_version: 3.8
+          - python_version: "3.9"
             script: tests
-          - python_version: 3.9
+          - python_version: "3.10"
             script: tests
 
     name: "py${{ matrix.python_version }} / ${{ matrix.script }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
   rev: "v2.29.0"
   hooks:
   - id: pyupgrade
+    args: [ --py37-plus ]
 
 - repo: https://github.com/PyCQA/doc8
   rev: "0.10.1"

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Procrastinate: PostgreSQL-based Task Queue for Python
     :alt: Contributor Covenant
 
 
-Procrastinate is an open-source Python 3.6+ distributed task processing
+Procrastinate is an open-source Python 3.7+ distributed task processing
 library, leveraging PostgreSQL to store task definitions, manage locks and
 dispatch tasks. It can be used within both sync and async code.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -209,7 +209,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.2"
+version = "3.10.1"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -221,8 +221,7 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
@@ -551,24 +550,17 @@ type_comments = ["typed-ast (>=1.4.0)"]
 
 [[package]]
 name = "sphinx-github-changelog"
-version = "1.0.2"
+version = "1.0.8"
 description = "Build a sphinx changelog from GitHub Releases"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
-docutils = "*"
-importlib-metadata = "*"
-requests = "*"
-sphinx = "*"
-
-[package.extras]
-dev = ["tox", "black", "isort"]
-docs = ["doc8", "sphinx (>=3.1.1)", "sphinx-github-changelog", "sphinx-rtd-theme"]
-docs_spelling = ["sphinxcontrib-spelling"]
-lint = ["black", "flake8", "isort", "mypy", "check-manifest"]
-test = ["pytest", "pytest-mock", "pytest-cov", "requests-mock"]
+docutils = ">=0.16,<0.17"
+importlib-metadata = {version = ">=3.10.1,<4.0.0", markers = "python_version < \"3.8\""}
+requests = ">=2.25.1,<3.0.0"
+Sphinx = ">=3.5.4,<4.0.0"
 
 [[package]]
 name = "sphinxcontrib-applehelp"
@@ -774,8 +766,8 @@ sqlalchemy = ["sqlalchemy"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "6dffe3b25c441de3bd8f1da8c40f7f29253e800ed2bbbe2d1b060e8610060781"
+python-versions = "^3.7"
+content-hash = "e234bb77c284f128c9341f0f195a76ff298d20a5621023082a918213cf62619f"
 
 [metadata.files]
 aiopg = [
@@ -948,8 +940,8 @@ imagesize = [
     {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
-    {file = "importlib_metadata-4.8.2.tar.gz", hash = "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"},
+    {file = "importlib_metadata-3.10.1-py3-none-any.whl", hash = "sha256:2ec0faae539743ae6aaa84b49a169670a465f7f5d64e6add98388cc29fd1f2f6"},
+    {file = "importlib_metadata-3.10.1.tar.gz", hash = "sha256:c9356b657de65c53744046fa8f7358afe0714a1af7d570c00c3835c2d724a7c1"},
 ]
 importlib-resources = [
     {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
@@ -964,22 +956,12 @@ jinja2 = [
     {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
 markupsafe = [
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -988,21 +970,14 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1012,9 +987,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1138,7 +1110,8 @@ sphinx-autodoc-typehints = [
     {file = "sphinx_autodoc_typehints-1.12.0-py3-none-any.whl", hash = "sha256:5e81776ec422dd168d688ab60f034fccfafbcd94329e9537712c93003bddc04a"},
 ]
 sphinx-github-changelog = [
-    {file = "sphinx-github-changelog-1.0.2.tar.gz", hash = "sha256:8af05b7aaeb7b6ffa81ceea7ffde34e0ab39d032879c57bbefb08c0c6bb12872"},
+    {file = "sphinx-github-changelog-1.0.8.tar.gz", hash = "sha256:8bfd68c0598182632511a92de3224fe38574537e742865f068bba601b00fd25c"},
+    {file = "sphinx_github_changelog-1.0.8-py3-none-any.whl", hash = "sha256:2b270eed3d8541403c6c71689cba21839f098a5b1aa66c0fcbaa5f029efcd7f9"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -71,7 +71,7 @@ def wrap_query_exceptions(coro: CoroutineFunction) -> CoroutineFunction:
                     continue
                 raise exc
         raise exceptions.ConnectorException(
-            "Could not get a valid connection after {} tries".format(max_tries)
+            f"Could not get a valid connection after {max_tries} tries"
         ) from final_exc
 
     return wrapped

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -128,7 +128,11 @@ def cli(ctx: click.Context, app: str, verbose, log_format, log_format_style) -> 
     ctx.default_map = {"worker": worker_defaults}
 
 
-@cli.resultcallback()
+# result_callback for click >=8.0, resultcallback for click <8.1
+result_callback = getattr(cli, "result_callback") or cli.resultcallback
+
+
+@result_callback()
 @click.pass_obj
 def close_connection(procrastinate_app: procrastinate.App, *args, **kwargs):
     # There's an internal click param named app, we can't name our variable "app" too.

--- a/procrastinate/psycopg2_connector.py
+++ b/procrastinate/psycopg2_connector.py
@@ -60,7 +60,7 @@ def wrap_query_exceptions(func: Callable) -> Callable:
             except psycopg2.errors.AdminShutdown:
                 continue
         raise exceptions.ConnectorException(
-            "Could not get a valid connection after {} tries".format(max_tries)
+            f"Could not get a valid connection after {max_tries} tries"
         ) from final_exc
 
     return wrapped

--- a/procrastinate/signals.py
+++ b/procrastinate/signals.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import signal
-import sys
 import threading
 from contextlib import contextmanager
 from typing import Any, Callable, Optional
@@ -37,16 +36,10 @@ def on_stop(callback: Callable[[], None]):
 
     uninstalled = False
     loop: Optional[asyncio.AbstractEventLoop]
-    if sys.version_info < (3, 7):  # coverage: exclude
-        if asyncio.Task.current_task():
-            loop = asyncio.get_event_loop()
-        else:
-            loop = None
-    else:  # coverage: exclude
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
 
     def uninstall_and_callback(*args) -> None:
         nonlocal uninstalled

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -149,6 +149,7 @@ def add_method_sync_api(*, cls: Type, method_name: str, suffix: str = "_async"):
 
     # Save this new method on the class
     wrapper.__name__ = sync_name
+    final_wrapper.__doc__ = final_wrapper.__doc__ or ""
     final_wrapper.__doc__ += SYNC_ADDENDUM.format(method_name)
     setattr(cls, sync_name, final_wrapper)
 

--- a/procrastinate_demo/__main__.py
+++ b/procrastinate_demo/__main__.py
@@ -41,7 +41,6 @@ async def main_async():
 if __name__ == "__main__":
     logging.basicConfig(level="DEBUG")
     if app.USE_ASYNC:
-        asyncio.get_event_loop().run_until_complete(main_async())
-        # asyncio.run(main_async())  # Python 3.7+
+        asyncio.run(main_async())
     else:
         main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: MIT License",
 ]
 readme = "README.rst"
@@ -25,7 +25,7 @@ documentation = "https://procrastinate.readthedocs.io/"
 procrastinate = 'procrastinate.cli:main'
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 aiopg = "*"
 attrs = "*"
 click = "*"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,7 +6,7 @@ import pytest
 class AsyncMock(MagicMock):
     """Provides a Mock object that can be awaited.
 
-    Unfortunately AsyncMock does not natively exists before python3.7.
+    Unfortunately AsyncMock does not natively exists before python3.8.
     """
 
     def __init__(self):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,7 +10,7 @@ class AsyncMock(MagicMock):
     """
 
     def __init__(self):
-        super(AsyncMock, self).__init__()
+        super().__init__()
         self.was_awaited = False
 
     def __await__(self):

--- a/tests/unit/test_psycopg2_connector.py
+++ b/tests/unit/test_psycopg2_connector.py
@@ -36,9 +36,9 @@ def test_wrap_query_exceptions_reached_max_tries(mocker, pool_args, called_count
         func(connector)
 
     assert len(called) == called_count
-    assert str(
-        excinfo.value
-    ) == "Could not get a valid connection after {} tries".format(called_count)
+
+    expected = f"Could not get a valid connection after {called_count} tries"
+    assert str(excinfo.value) == expected
 
 
 def test_wrap_query_exceptions_unhandled_exception(mocker):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ isolated_build = True
 requires =
     tox-poetry-dev-dependencies
 envlist =
-    {py36,py37,py38,py39}-tests,lint,docs
+    py{37,38,39,310}-tests,lint,docs
 
 [testenv]
 poetry_add_dev_dependencies = True


### PR DESCRIPTION
The warning filters we need to setup to have tests pass without warnings (all from Django):
```
    ignore:The distutils package:DeprecationWarning
    ignore:'procrastinate.contrib.django' defines default_app_config:django.utils.deprecation.RemovedInDjango41Warning
    ignore:There is no current event loop:DeprecationWarningCloses #<ticket number>
```

Py36 is deprecated starting on Dec. 23, but I believe it's ok if we remove it already. It doesn't mean our 3.6 users are blocked, just that they can't have the latest updates.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)
