### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,7 @@ name: Deploy
 on:
   push:
     tags:
-      - '*'
-  release:
-    types:
-      - published
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   deploy:


### PR DESCRIPTION
I've noticed that when we publish a Release, there are 2 events fired.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
