### PR TITLE
Switch to python-coverage-comment-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,22 +96,14 @@ jobs:
         with:
           name: 'coverage'
 
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v2
-
-      # There's no assurance that this will be the same version as the coverage
-      # in poetry.lock, but this should not be a problem.
-      - name: Install PyCoverage
-        run: pip install coverage
-
-      - name: Combine coverage files
-        run: coverage combine
-
-      - name: Produce coverage.xml
-        run: coverage xml
-
       - name: Display coverage
-        uses: ewjoachim/coverage-comment-action@v1
+        uses: ewjoachim/python-coverage-comment-action@v2
         with:
+          MERGE_COVERAGE_FILES: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Store Pull Request comment to be posted
+        uses: actions/upload-artifact@v2
+        with:
+          name: python-coverage-comment-action
+          path: python-coverage-comment-action.txt

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,23 @@
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  test:
+    name: Run tests & display coverage
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      # DO NOT run actions/checkout@v2 here, for securitity reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: ewjoachim/python-coverage-comment-action@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Procrastinate: PostgreSQL-based Task Queue for Python
     :target: http://procrastinate.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation
 
-.. image:: https://img.shields.io/endpoint?logo=codecov&logoColor=white&url=https://raw.githubusercontent.com/wiki/procrastinate-org/procrastinate/coverage-comment-badge.json
+.. image:: https://img.shields.io/endpoint?logo=codecov&logoColor=white&url=https://raw.githubusercontent.com/wiki/procrastinate-org/procrastinate/python-coverage-comment-action-badge.json
     :target: https://github.com/marketplace/actions/coverage-comment
     :alt: Coverage
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [coverage:run]
+relative_files = true
 omit =
     procrastinate/contrib/django/migrations/*
 


### PR DESCRIPTION
Switch to from coverage-comment-action to [python-coverage-comment-action](https://github.com/marketplace/actions/python-coverage-comment) which supports external PRs

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
