### PR TITLE
Revert changes to the deploy workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - '*'
+  release:
+    types:
+      - published
 
 jobs:
   deploy:


### PR DESCRIPTION
This is really strange. When we had both `release publish` and `tag push`, I saw 2 workflows firing when I published a release. I removed `release publish` and now there is zero... :shrug: 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
