### PR TITLE
clarify schedule_in docstring

### DIFF
--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -160,8 +160,8 @@ class Task:
             A datetime before which the job should not be launched (incompatible with
             schedule_in)
         schedule_in :
-            A dict describing the time interval before the task should be launched.
-            See details in the `python documentation
+            A dict with kwargs for a python timedelta, for example `{'minutes': 5}`.
+            Converted to schedule_at internally. See `python timedelta documentation
             <https://docs.python.org/3/library/datetime.html#timedelta-objects>`__
             (incompatible with schedule_at)
 

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -160,7 +160,7 @@ class Task:
             A datetime before which the job should not be launched (incompatible with
             schedule_in)
         schedule_in :
-            A dict with kwargs for a python timedelta, for example `{'minutes': 5}`.
+            A dict with kwargs for a python timedelta, for example ``{'minutes': 5}``.
             Converted to schedule_at internally. See `python timedelta documentation
             <https://docs.python.org/3/library/datetime.html#timedelta-objects>`__
             (incompatible with schedule_at)


### PR DESCRIPTION
Closes #592

More explicitly specifies that schedule_in takes timedelta kwargs, adds an example.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)
