### PR TITLE
SQL Alchemy integrity Error (& hole in coverage)

### DIFF
--- a/procrastinate/contrib/sqlalchemy/psycopg2_connector.py
+++ b/procrastinate/contrib/sqlalchemy/psycopg2_connector.py
@@ -23,6 +23,7 @@ def wrap_exceptions(func: Callable) -> Callable:
                 raise exceptions.UniqueViolation(
                     constraint_name=exc.orig.diag.constraint_name
                 )
+            raise exceptions.ConnectorException from exc
         except sqlalchemy.exc.SQLAlchemyError as exc:
             raise exceptions.ConnectorException from exc
 

--- a/tests/unit/contrib/sqlalchemy/test_psycopg2_connector.py
+++ b/tests/unit/contrib/sqlalchemy/test_psycopg2_connector.py
@@ -35,6 +35,17 @@ def test_wrap_exceptions_unique_violation(mocker):
     assert excinfo.value.constraint_name == "constraint name"
 
 
+def test_wrap_exceptions_integrity_error_not_unique(mocker):
+    @sqlalchemy_psycopg2_connector.wrap_exceptions
+    def func():
+        exc = Exception()
+        exc.diag = mocker.Mock(constraint_name="constraint name")
+        raise sqlalchemy.exc.IntegrityError(statement="SELECT 1", params={}, orig=exc)
+
+    with pytest.raises(exceptions.ConnectorException):
+        func()
+
+
 def test_wrap_exceptions_success():
     @sqlalchemy_psycopg2_connector.wrap_exceptions
     def func(a, b):


### PR DESCRIPTION
In cas sqlalchemy issued an IntegrityError not based on a UniqueViolation, the exception was swallowed.
Also, this was not tested properly, so we had 99% in coverage

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
