### PR TITLE
friendly error for get_full_path failures

### DIFF
--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -120,3 +120,7 @@ class InvalidTimestamp(ProcrastinateException):
     Periodic task launched with a timestamp kwarg not matching the
     defer_timestamp arg
     """
+
+
+class FunctionPathError(ProcrastinateException):
+    """Couldn't automatically generate a unique name for a function"""

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -235,8 +235,12 @@ def _get_module_name(obj: Any) -> str:
 
 
 def get_full_path(obj: Any) -> str:
-
-    return f"{_get_module_name(obj)}.{obj.__name__}"
+    try:
+        return f"{_get_module_name(obj)}.{obj.__name__}"
+    except AttributeError as exc:
+        raise exceptions.FunctionPathError(
+            f"Couldn't automatically name {type(obj)}. Try passing `name=` to the task decorator"
+        ) from exc
 
 
 def utcnow() -> datetime.datetime:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import functools
 import sys
 import time
 import types
@@ -229,6 +230,11 @@ def test_get_full_path():
     path = "procrastinate.utils.get_full_path"
     # Calling the function on itself
     assert utils.get_full_path(utils.get_full_path) == path
+
+
+def test_get_full_path_partial():
+    with pytest.raises(exceptions.FunctionPathError):
+        utils.get_full_path(functools.partial(test_get_full_path_partial))
 
 
 # `launched` and `finished` are sets used by the run_tasks tests, both coro and


### PR DESCRIPTION
Closes #674

## Changes
- `utils.get_full_path` throws error on failure, with instructions for resolving
- new exception `FunctionPathError`
- added test

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
