### PR TITLE
Fix code of conduct url in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Procrastinate: PostgreSQL-based Task Queue for Python
     :alt: MIT License
 
 .. image:: https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg
-    :target: https://github.com/procrastinate-org/procrastinate/blob/main/LICENSE/CODE_OF_CONDUCT.md
+    :target: https://github.com/procrastinate-org/procrastinate/blob/main/CODE_OF_CONDUCT.md
     :alt: Contributor Covenant
 
 


### PR DESCRIPTION
Hi there ! The link to the code of conduct was broken. This fixes it :) 

### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [x] not applicable
- [x] Documentation
  - [x] not applicable
