### PR TITLE
Update middleware docs

### DIFF
--- a/docs/howto/middleware.rst
+++ b/docs/howto/middleware.rst
@@ -7,6 +7,8 @@ your own decorator instead of ``@app.task`` and have this decorator
 implement the actions you need and delegate the rest to ``@app.task``.
 It might look like this::
 
+    import functools
+
     def task(*args, **kwargs):
         def wrap(func):
             def new_func(*job_args, **job_kwargs):
@@ -16,7 +18,8 @@ It might look like this::
                 log_something_else()
                 return result
 
-            return app.task(*args, **kwargs)(new_func)
+            wrapped_func = functools.update_wrapper(new_func, func, updated=())
+            return app.task(*args, **kwargs)(wrapped_func)
         return wrap
 
 Then, define all of your tasks using this ``@task`` decorator.

--- a/docs/howto/middleware.rst
+++ b/docs/howto/middleware.rst
@@ -9,7 +9,7 @@ It might look like this::
 
     import functools
 
-    def task(*args, **kwargs):
+    def task(original_func=None, *args, **kwargs):
         def wrap(func):
             def new_func(*job_args, **job_kwargs):
                 # This is the custom part
@@ -20,6 +20,10 @@ It might look like this::
 
             wrapped_func = functools.update_wrapper(new_func, func, updated=())
             return app.task(*args, **kwargs)(wrapped_func)
+
+    if not original_func:
         return wrap
+
+    return wrap(original_func)
 
 Then, define all of your tasks using this ``@task`` decorator.

--- a/docs/howto/middleware.rst
+++ b/docs/howto/middleware.rst
@@ -21,9 +21,9 @@ It might look like this::
             wrapped_func = functools.update_wrapper(new_func, func, updated=())
             return app.task(*args, **kwargs)(wrapped_func)
 
-    if not original_func:
-        return wrap
+        if not original_func:
+            return wrap
 
-    return wrap(original_func)
+        return wrap(original_func)
 
 Then, define all of your tasks using this ``@task`` decorator.


### PR DESCRIPTION
The code in the middleware docs wasn't working for me when I tried to call .defer_async() on the wrapped function, I was getting this error

```
    await noop.defer_async()
AttributeError: 'function' object has no attribute 'defer_async'
```

This only happens when I use the decorator like `@task` , but when I use it like `@task()`, it works.

I was also getting this error

```
    f"A task named {name} was already registered"
procrastinate.exceptions.TaskAlreadyRegistered: A task named src.tasks.app.new_func was already registered
```

Likely because I have multiple tasks using the `@task` decorator, so it was registering the inner `new_func` function instead of the original one.

The new code I submitted fixes the issue.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)
