### PR TITLE
Set encoding=utf-8 when reading files

### DIFF
--- a/procrastinate/contrib/django/migrations_magic.py
+++ b/procrastinate/contrib/django/migrations_magic.py
@@ -72,7 +72,7 @@ def list_migration_files() -> Iterable[Tuple[str, str]]:
     Returns a list of filenames and file contents for all migration files
     """
     return [
-        (p.name, p.read_text())
+        (p.name, p.read_text(encoding="utf-8"))
         for p in importlib_resources.files("procrastinate.sql.migrations").iterdir()
         if p.name.endswith(".sql")
     ]

--- a/procrastinate/schema.py
+++ b/procrastinate/schema.py
@@ -20,7 +20,7 @@ class SchemaManager:
     def get_schema() -> str:
         return (
             importlib_resources.files("procrastinate.sql") / "schema.sql"
-        ).read_text()
+        ).read_text(encoding="utf-8")
 
     @staticmethod
     def get_migrations_path() -> str:

--- a/procrastinate/sql/__init__.py
+++ b/procrastinate/sql/__init__.py
@@ -27,7 +27,7 @@ def parse_query_file(query_file: str) -> Dict["str", "str"]:
 
 def get_queries() -> Dict["str", "str"]:
     return parse_query_file(
-        (importlib_resources.files("procrastinate.sql") / "queries.sql").read_text()
+        (importlib_resources.files("procrastinate.sql") / "queries.sql").read_text(encoding="utf-8")
     )
 
 

--- a/procrastinate/sql/__init__.py
+++ b/procrastinate/sql/__init__.py
@@ -27,7 +27,9 @@ def parse_query_file(query_file: str) -> Dict["str", "str"]:
 
 def get_queries() -> Dict["str", "str"]:
     return parse_query_file(
-        (importlib_resources.files("procrastinate.sql") / "queries.sql").read_text(encoding="utf-8")
+        (importlib_resources.files("procrastinate.sql") / "queries.sql").read_text(
+            encoding="utf-8"
+        )
     )
 
 


### PR DESCRIPTION
(No ticket raised)

To avoid encoding warnings running under python 3.10+.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)
