### PR TITLE
Apply future migrations following the release of 1.0

### DIFF
--- a/procrastinate/sql/future_migrations/01.00.00_02_periodic_id.sql
+++ b/procrastinate/sql/future_migrations/01.00.00_02_periodic_id.sql
@@ -1,6 +1,0 @@
-
--- https://github.com/procrastinate-org/procrastinate/pull/471
-DROP FUNCTION IF EXISTS procrastinate_defer_periodic_job(character varying, character varying, character varying, character varying, bigint);
-
-ALTER TABLE procrastinate_periodic_defers
-    DROP COLUMN "queue_name";

--- a/procrastinate/sql/future_migrations/02.00.00_01_drop_old_procrastinate_finish_job.sql
+++ b/procrastinate/sql/future_migrations/02.00.00_01_drop_old_procrastinate_finish_job.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS procrastinate_finish_job(integer, procrastinate_job_status, timestamp with time zone, boolean);

--- a/procrastinate/sql/migrations/01.00.00_01_remove_old_finish_job_function.sql
+++ b/procrastinate/sql/migrations/01.00.00_01_remove_old_finish_job_function.sql
@@ -7,8 +7,7 @@ DROP FUNCTION IF EXISTS procrastinate_finish_job(integer, procrastinate_job_stat
 DROP FUNCTION IF EXISTS procrastinate_finish_job(integer, procrastinate_job_status);
 
 -- https://github.com/procrastinate-org/procrastinate/pull/381
-DROP FUNCTION IF EXISTS procrastinate_finish_job(integer, procrastinate_job_status, timestamp with time zone, boolean);
-CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, delete_job boolean) RETURNS void
+CREATE OR REPLACE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, delete_job boolean) RETURNS void
     LANGUAGE plpgsql
 AS $$
 DECLARE
@@ -37,3 +36,8 @@ BEGIN
     END IF;
 END;
 $$;
+
+-- https://github.com/procrastinate-org/procrastinate/pull/471
+DROP FUNCTION IF EXISTS procrastinate_defer_periodic_job(character varying, character varying, character varying, character varying, bigint);
+
+ALTER TABLE procrastinate_periodic_defers DROP COLUMN "queue_name";

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -48,7 +48,7 @@ WHERE id IN (
 
 -- finish_job --
 -- Finish a job, changing it from "doing" to "succeeded" or "failed"
-SELECT procrastinate_finish_job(%(job_id)s, %(status)s, NULL, %(delete_job)s);
+SELECT procrastinate_finish_job(%(job_id)s, %(status)s, %(delete_job)s);
 
 -- retry_job --
 -- Retry a job, changing it from "doing" to "todo"

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -40,7 +40,6 @@ CREATE TABLE procrastinate_periodic_defers (
     task_name character varying(128) NOT NULL,
     defer_timestamp bigint,
     job_id bigint REFERENCES procrastinate_jobs(id) NULL,
-    queue_name character varying(128) NULL,
     periodic_id character varying(128) NOT NULL DEFAULT '',
     CONSTRAINT procrastinate_periodic_defers_unique UNIQUE (task_name, periodic_id, defer_timestamp)
 );
@@ -183,7 +182,7 @@ $$;
 -- procrastinate_finish_job
 -- the next_scheduled_at argument is kept for compatibility reasons, it is to be
 -- removed after 1.0.0 is released
-CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, next_scheduled_at timestamp with time zone, delete_job boolean) RETURNS void
+CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, delete_job boolean) RETURNS void
     LANGUAGE plpgsql
 AS $$
 DECLARE
@@ -336,80 +335,34 @@ CREATE TRIGGER procrastinate_trigger_delete_jobs
 
 
 -- Old versions of functions, for backwards compatibility (to be removed
--- after 1.0.0)
-
-CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, next_scheduled_at timestamp with time zone) RETURNS void
+-- after 2.0.0)
+-- procrastinate_finish_job
+CREATE OR REPLACE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, next_scheduled_at timestamp with time zone, delete_job boolean) RETURNS void
     LANGUAGE plpgsql
 AS $$
-BEGIN
-    UPDATE procrastinate_jobs
-    SET status = end_status,
-        attempts = attempts + 1,
-        scheduled_at = COALESCE(next_scheduled_at, scheduled_at)
-    WHERE id = job_id;
-END;
-$$;
-
-CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status) RETURNS void
-    LANGUAGE plpgsql
-AS $$
-BEGIN
-    UPDATE procrastinate_jobs
-    SET status = end_status,
-        attempts = attempts + 1
-    WHERE id = job_id;
-END;
-$$;
-
-CREATE FUNCTION procrastinate_defer_periodic_job(
-    _queue_name character varying,
-    _lock character varying,
-    _queueing_lock character varying,
-    _task_name character varying,
-    _defer_timestamp bigint
-) RETURNS bigint
-    LANGUAGE plpgsql
-    AS $$
 DECLARE
-	_job_id bigint;
-	_defer_id bigint;
+    _job_id bigint;
 BEGIN
-
-    INSERT
-        INTO procrastinate_periodic_defers (task_name, queue_name, defer_timestamp)
-        VALUES (_task_name, _queue_name, _defer_timestamp)
-        ON CONFLICT DO NOTHING
-        RETURNING id into _defer_id;
-
-    IF _defer_id IS NULL THEN
-        RETURN NULL;
+    IF end_status NOT IN ('succeeded', 'failed') THEN
+        RAISE 'End status should be either "succeeded" or "failed" (job id: %)', job_id;
     END IF;
-
-    UPDATE procrastinate_periodic_defers
-        SET job_id = procrastinate_defer_job(
-                _queue_name,
-                _task_name,
-                _lock,
-                _queueing_lock,
-                ('{"timestamp": ' || _defer_timestamp || '}')::jsonb,
-                NULL
-            )
-        WHERE id = _defer_id
-        RETURNING job_id INTO _job_id;
-
-    DELETE
-        FROM procrastinate_periodic_defers
-        USING (
-            SELECT id
-            FROM procrastinate_periodic_defers
-            WHERE procrastinate_periodic_defers.task_name = _task_name
-            AND procrastinate_periodic_defers.queue_name = _queue_name
-            AND procrastinate_periodic_defers.defer_timestamp < _defer_timestamp
-            ORDER BY id
-            FOR UPDATE
-        ) to_delete
-        WHERE procrastinate_periodic_defers.id = to_delete.id;
-
-    RETURN _job_id;
+    IF delete_job THEN
+        DELETE FROM procrastinate_jobs
+        WHERE id = job_id AND status IN ('todo', 'doing')
+        RETURNING id INTO _job_id;
+    ELSE
+        UPDATE procrastinate_jobs
+        SET status = end_status,
+            attempts =
+                CASE
+                    WHEN status = 'doing' THEN attempts + 1
+                    ELSE attempts
+                END
+        WHERE id = job_id AND status IN ('todo', 'doing')
+        RETURNING id INTO _job_id;
+    END IF;
+    IF _job_id IS NULL THEN
+        RAISE 'Job was not found or not in "doing" or "todo" status (job id: %)', job_id;
+    END IF;
 END;
 $$;


### PR DESCRIPTION
Now that 1.0 has been released, following our [migration doc](https://procrastinate.readthedocs.io/en/stable/howto/migrations.html), we should remove compatibility SQL.

(note: some change will need a second step, so we already have migrations lined up for v2)

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
