### PR TITLE
Fix index

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,8 @@ feel free to open an [issue](https://github.com/procrastinate-org/procrastinate/
 *Note to my future self: add a quick note here on why this project is named*
 "[Procrastinate]" ;) .
 
-% Below this line is content specific to the README that will not appear in the doc.
-
-% end-of-index-doc
+<!--Below this line is content that will appear in the GitHub Readme but not in the
+Sphinx doc: end-of-index-doc -->
 
 ## Where to go from here
 


### PR DESCRIPTION
Bottom of the GitHub README is broken. Fixes it.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
