### PR TITLE
DjangoConnector.get_worker_connector() uses psycopg3 if available

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,15 +5,16 @@
 # Required
 version: 2
 
-sphinx:
-  fail_on_warning: true
-
 build:
-  os: ubuntu-20.04
+  os: "ubuntu-22.04"
   tools:
     python: "3.10"
   jobs:
+    post_create_environment:
+      - python -m pip install poetry
     post_install:
-      - pip install -U poetry
-      - poetry config virtualenvs.create false
-      - poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH python -m poetry install --with docs
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true

--- a/docs/howto/django.md
+++ b/docs/howto/django.md
@@ -87,8 +87,10 @@ itself, with some commands removed and the app is configured for you.
 You can also use other subcommands such as `./manage.py procrastinate defer`.
 
 :::{note}
-Procrastinate generates an app for you using a Psycopg or Aiopg connector
-depending on your Django setup, and connects using the `DATABASES` settings.
+Procrastinate generates an app for you using a `Psycopg` (by default) or
+`Aiopg` connector depending on whether `psycopg3` or `aiopg` is
+installed, and connects using the `DATABASES` settings. If neither library is
+installed, an error will be raised.
 :::
 
 ## Deferring jobs
@@ -189,8 +191,12 @@ if __name__ == "__main__":
     main()
 ```
 :::{note}
-The ``.get_worker_connector()`` method is only available on `DjangoConnector`
+The `.get_worker_connector()` method is only available on `DjangoConnector`
 and the API isn't guaranteed to be stable.
+:::
+:::{note}
+As mentionned above, either `psycopg` or `aiopg` need to be installed.
+`psycopg` will be used by default.
 :::
 
 ## Alternatives

--- a/procrastinate/contrib/django/utils.py
+++ b/procrastinate/contrib/django/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 from typing import Any
 
 from django.conf import settings
@@ -31,3 +32,7 @@ def connector_params(alias: str = "default") -> dict[str, Any]:
 
 def get_setting(name: str, *, default) -> Any:
     return getattr(settings, f"PROCRASTINATE_{name}", default)
+
+
+def package_is_installed(name: str) -> bool:
+    return bool(importlib.util.find_spec(name))

--- a/tests/unit/contrib/django/test_utils.py
+++ b/tests/unit/contrib/django/test_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from procrastinate.contrib.django import utils
 
 
@@ -14,3 +16,14 @@ def test_get_settings(settings):
 
 def test_get_settings_default():
     assert utils.get_setting("FOO", default="baz") == "baz"
+
+
+@pytest.mark.parametrize(
+    "package_name, expected",
+    [
+        ("foo" * 30, False),
+        ("pytest", True),
+    ],
+)
+def test_package_is_installed(package_name, expected):
+    assert utils.package_is_installed(package_name) is expected


### PR DESCRIPTION
Relates to #934

(also, fixes the RTD build)

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
