### PR TITLE
Add explicit error message if users use the django app before .ready()

### DIFF
--- a/docs/howto/django.md
+++ b/docs/howto/django.md
@@ -49,7 +49,6 @@ def on_app_ready(app: procrastinate.App):
     app.add_tasks_from(some_blueprint)
 ```
 
-
 :::{note}
 It's likely that configuring an app yourself and using it instead of the
 one provided by Procrastinate will lead to all sorts of issues.
@@ -167,12 +166,28 @@ DATABASE_ALIAS: str,  # (defaults to "default")
 # These settings are passed as-is to the App constructor.
 WORKER_DEFAULTS: dict | None,  # (defaults to None)
 PERIODIC_DEFAULTS: dict | None,  # (defaults to None)
+
+# Dotted path to a function to run when the app is ready (see above).
+PROCRASTINATE_ON_APP_READY: str
 ```
 
 ## Logs
 
 Procrastinate logs to the `procrastinate` logger. You can configure it
 in your `LOGGING` settings.
+
+## Startup actions
+
+If you need to interact with Procrastinate at startup, you may be tempted to
+put some code directly at the top-level of a module, for it to run at import
+time. The `procrastinate.contrib.django` app is not started yet and will
+raise an error in this case. The recommended ways to do this is:
+
+- Use the `PROCRASTINATE_ON_APP_READY` setting to run code when the app is
+  ready.
+- Use Django's [`AppConfig.ready()`] method to run your code when the app is
+  started. In that case, ensure that the `procrastinate.contrib.django` app
+  is located before your app in the `INSTALLED_APPS` list.
 
 ## Advanced: Running the worker without the official management command
 If you want to run the worker yourself, it's possible but slightly more convoluted.
@@ -211,3 +226,4 @@ postgres' LISTEN/NOTIFY that integrate with Django. For instance,
 [pending issues]: https://github.com/procrastinate-org/procrastinate/issues?q=is%3Aissue+is%3Aopen+django
 [open an issue]: https://github.com/procrastinate-org/procrastinate/issues
 [this talk at djangocon 2019]: https://www.youtube.com/watch?v=_DIlE-yc9ZQ
+[`AppConfig.ready()`]: https://docs.djangoproject.com/en/5.0/ref/applications/#django.apps.AppConfig.ready

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -131,6 +131,9 @@ class App(blueprints.Blueprint):
             alias="procrastinate.builtin_tasks.remove_old_jobs",
         )
 
+    def will_configure_task(self) -> None:
+        pass
+
     def configure_task(
         self, name: str, *, allow_unknown: bool = True, **kwargs: Any
     ) -> jobs.JobDeferrer:

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -283,3 +283,6 @@ class Blueprint:
         return self.periodic_registry.periodic_decorator(
             cron=cron, periodic_id=periodic_id, **kwargs
         )
+
+    def will_configure_task(self) -> None:
+        raise exceptions.UnboundTaskError

--- a/procrastinate/contrib/django/__init__.py
+++ b/procrastinate/contrib/django/__init__.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import cast
 
-import procrastinate
+from procrastinate import app as app_module
 
+from .placeholder import FutureApp
 from .router import ProcrastinateReadOnlyRouter
 from .utils import connector_params
 
@@ -17,4 +18,6 @@ default_app_config = "procrastinate.contrib.django.apps.ProcrastinateConfig"
 # Before the Django app is ready, we're defining the app as a blueprint so
 # that tasks can be registered. The real app will be initialized in the
 # ProcrastinateConfig.ready() method.
-app: procrastinate.App = cast(procrastinate.App, procrastinate.Blueprint())
+# This blueprint has special implementations for App method so that if
+# users try to use the app before it's ready, they get a helpful error message.
+app: app_module.App = cast(app_module.App, FutureApp())

--- a/procrastinate/contrib/django/exceptions.py
+++ b/procrastinate/contrib/django/exceptions.py
@@ -5,3 +5,7 @@ from procrastinate import exceptions
 
 class ReadOnlyModel(exceptions.ProcrastinateException):
     pass
+
+
+class DjangoNotReady(exceptions.ProcrastinateException):
+    pass

--- a/procrastinate/contrib/django/placeholder.py
+++ b/procrastinate/contrib/django/placeholder.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import functools
+from typing import NoReturn
+
+from procrastinate import blueprints
+
+from . import exceptions
+
+
+def _not_ready(_method: str, *args, **kwargs) -> NoReturn:
+    base_text = (
+        f"Cannot call procrastinate.contrib.app.{_method}() before "
+        "the 'procrastinate.contrib.django' django app is ready."
+    )
+    details = (
+        "If this message appears at import time, the app is not ready yet: "
+        "move the corresponding code in an app's `AppConfig.ready()` method. "
+        "If this message appears in an app's `AppConfig.ready()` method, "
+        'make sure `"procrastinate.contrib.django"` appears before '
+        "that app when ordering apps in the Django setting `INSTALLED_APPS`. "
+        "Alternatively, use the Django setting "
+        "PROCRASTINATE_ON_APP_READY (see the doc)."
+    )
+    raise exceptions.DjangoNotReady(base_text + "\n\n" + details)
+
+
+class FutureApp(blueprints.Blueprint):
+    _shadowed_methods = frozenset(
+        [
+            "__enter__",
+            "__exit__",
+            "_register_builtin_tasks",
+            "_worker",
+            "check_connection_async",
+            "check_connection",
+            "close_async",
+            "close",
+            "configure_task",
+            "open_async",
+            "open",
+            "perform_import_paths",
+            "run_worker_async",
+            "run_worker",
+            "schema_manager",
+            "with_connector",
+            "will_configure_task",
+        ]
+    )
+    for method in _shadowed_methods:
+        locals()[method] = functools.partial(_not_ready, method)

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from procrastinate import app as app_module
 from procrastinate import blueprints, exceptions, jobs, manager, types, utils
@@ -179,10 +179,9 @@ class Task:
         ValueError
             If you try to define both schedule_at and schedule_in
         """
-        if not isinstance(self.blueprint, app_module.App):
-            raise exceptions.UnboundTaskError
+        self.blueprint.will_configure_task()
 
-        app = self.blueprint
+        app = cast(app_module.App, self.blueprint)
 
         return configure_task(
             name=self.name,

--- a/tests/unit/contrib/django/test_placeholder.py
+++ b/tests/unit/contrib/django/test_placeholder.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from procrastinate import app, blueprints
+from procrastinate.contrib.django import exceptions, placeholder
+
+
+def test__not_ready():
+    message = (
+        r"Cannot call procrastinate.contrib.app.foo\(\) before the "
+        r"'procrastinate.contrib.django' django app is ready\."
+    )
+    with pytest.raises(
+        exceptions.DjangoNotReady,
+        match=message,
+    ):
+        placeholder._not_ready("foo")
+
+
+def test_FutureApp__not_ready():
+    with pytest.raises(exceptions.DjangoNotReady):
+        placeholder.FutureApp().open()
+
+
+def test_FutureApp__defer():
+    app = placeholder.FutureApp()
+
+    @app.task
+    def foo():
+        pass
+
+    with pytest.raises(exceptions.DjangoNotReady):
+        foo.defer()
+
+
+def test_FutureApp__shadowed_methods():
+    ignored = {"from_path"}
+    added = {"will_configure_task"}
+    app_methods = set(dir(app.App)) - set(dir(blueprints.Blueprint)) - ignored | added
+    assert sorted(placeholder.FutureApp._shadowed_methods) == sorted(app_methods)


### PR DESCRIPTION
Relates to #934 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
