### PR TITLE
Fix psycopg3 detection

### DIFF
--- a/docs/howto/django.md
+++ b/docs/howto/django.md
@@ -87,7 +87,7 @@ You can also use other subcommands such as `./manage.py procrastinate defer`.
 
 :::{note}
 Procrastinate generates an app for you using a `Psycopg` (by default) or
-`Aiopg` connector depending on whether `psycopg3` or `aiopg` is
+`Aiopg` connector depending on whether `psycopg` version 3 or `aiopg` is
 installed, and connects using the `DATABASES` settings. If neither library is
 installed, an error will be raised.
 :::

--- a/procrastinate/contrib/django/django_connector.py
+++ b/procrastinate/contrib/django/django_connector.py
@@ -127,7 +127,9 @@ class DjangoConnector(connector.BaseAsyncConnector):
         """
         alias = utils.get_setting("DATABASE_ALIAS", default="default")
 
-        if utils.package_is_installed("psycopg") and utils.package_is_version("psycopg", 3):
+        if utils.package_is_installed("psycopg") and utils.package_is_version(
+            "psycopg", 3
+        ):
             from procrastinate import psycopg_connector
 
             return psycopg_connector.PsycopgConnector(

--- a/procrastinate/contrib/django/django_connector.py
+++ b/procrastinate/contrib/django/django_connector.py
@@ -127,7 +127,7 @@ class DjangoConnector(connector.BaseAsyncConnector):
         """
         alias = utils.get_setting("DATABASE_ALIAS", default="default")
 
-        if utils.package_is_installed("psycopg3"):
+        if utils.package_is_installed("psycopg") and utils.package_is_version("psycopg", 3):
             from procrastinate import psycopg_connector
 
             return psycopg_connector.PsycopgConnector(

--- a/procrastinate/contrib/django/utils.py
+++ b/procrastinate/contrib/django/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import importlib.util
 import importlib.metadata
+import importlib.util
 from typing import Any
 
 from django.conf import settings

--- a/procrastinate/contrib/django/utils.py
+++ b/procrastinate/contrib/django/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import importlib.metadata
 from typing import Any
 
 from django.conf import settings
@@ -36,3 +37,11 @@ def get_setting(name: str, *, default) -> Any:
 
 def package_is_installed(name: str) -> bool:
     return bool(importlib.util.find_spec(name))
+
+
+def package_is_version(name: str, version: int) -> bool:
+    """Assumes the version is written with dots"""
+    v = metadata.version(name)
+    if "." not in v:
+        return False
+    return int(v.split(".")[0]) == version

--- a/procrastinate/contrib/django/utils.py
+++ b/procrastinate/contrib/django/utils.py
@@ -41,7 +41,7 @@ def package_is_installed(name: str) -> bool:
 
 def package_is_version(name: str, version: int) -> bool:
     """Assumes the version is written with dots"""
-    v = metadata.version(name)
-    if "." not in v:
+    v = importlib.metadata.version(name)
+    if not v or "." not in v:
         return False
     return int(v.split(".")[0]) == version

--- a/procrastinate/contrib/django/utils.py
+++ b/procrastinate/contrib/django/utils.py
@@ -39,9 +39,9 @@ def package_is_installed(name: str) -> bool:
     return bool(importlib.util.find_spec(name))
 
 
-def package_is_version(name: str, version: int) -> bool:
-    """Assumes the version is written with dots"""
-    v = importlib.metadata.version(name)
-    if not v or "." not in v:
-        return False
-    return int(v.split(".")[0]) == version
+def package_is_version(name: str, major: int) -> bool:
+    """
+    Check if package's (PEP440) version matches given major version number
+    """
+    version = importlib.metadata.version(name)
+    return bool(version) and version.split(".")[0] == f"{major}"

--- a/tests/integration/contrib/django/test_django_connector.py
+++ b/tests/integration/contrib/django/test_django_connector.py
@@ -82,7 +82,7 @@ def test_execute_query_sync(django_connector):
 @pytest.mark.parametrize(
     "installed, type",
     [
-        ({"psycopg3"}, psycopg_connector.PsycopgConnector),
+        ({"psycopg"}, psycopg_connector.PsycopgConnector),
         ({"aiopg"}, aiopg_connector.AiopgConnector),
     ],
 )

--- a/tests/unit/contrib/django/test_utils.py
+++ b/tests/unit/contrib/django/test_utils.py
@@ -40,7 +40,7 @@ def test_package_is_installed(package_name, expected):
         (None, 3, False),
     ],
 )
-def test_package_is_version(version, version_wanted, expected):
-    with patch("importlib.metadata.version") as mock:
-        mock.return_value = version
-        assert utils.package_is_version("abcd", version_wanted) is expected
+def test_package_is_version(version, version_wanted, expected, mocker):
+    mocker.patch("importlib.metadata.version", return_value=version)
+    
+    assert utils.package_is_version("abcd", version_wanted) is expected

--- a/tests/unit/contrib/django/test_utils.py
+++ b/tests/unit/contrib/django/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from unittest.mock import patch
 
 from procrastinate.contrib.django import utils
 
@@ -27,3 +28,17 @@ def test_get_settings_default():
 )
 def test_package_is_installed(package_name, expected):
     assert utils.package_is_installed(package_name) is expected
+
+@pytest.mark.parametrize(
+    "version, version_wanted,expected",
+    [
+        ("3.1.3", 3, True),
+        ("2.1.3", 3, False),
+        ("pytest", 3, False),
+        (None, 3, False),
+    ],
+)
+def test_package_is_version(version, version_wanted, expected):
+    with patch("importlib.metadata.version") as mock:
+        mock.return_value = version
+        assert utils.package_is_version("abcd", version_wanted) is expected

--- a/tests/unit/contrib/django/test_utils.py
+++ b/tests/unit/contrib/django/test_utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
 from procrastinate.contrib.django import utils
@@ -42,5 +40,5 @@ def test_package_is_installed(package_name, expected):
 )
 def test_package_is_version(version, version_wanted, expected, mocker):
     mocker.patch("importlib.metadata.version", return_value=version)
-    
+
     assert utils.package_is_version("abcd", version_wanted) is expected

--- a/tests/unit/contrib/django/test_utils.py
+++ b/tests/unit/contrib/django/test_utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from procrastinate.contrib.django import utils
 
@@ -28,6 +29,7 @@ def test_get_settings_default():
 )
 def test_package_is_installed(package_name, expected):
     assert utils.package_is_installed(package_name) is expected
+
 
 @pytest.mark.parametrize(
     "version, version_wanted,expected",


### PR DESCRIPTION
psycopg 3 is installed using the psycopg package, not pyscopg3.
Haven't had time to add the tests but it should easy to mock out importlib.metadata.version. Will do ASAP

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
