### PR TITLE
Add logs, evolve Django demo to use blueprints

### DIFF
--- a/docs/howto/django.md
+++ b/docs/howto/django.md
@@ -174,7 +174,10 @@ PROCRASTINATE_ON_APP_READY: str
 ## Logs
 
 Procrastinate logs to the `procrastinate` logger. You can configure it
-in your `LOGGING` settings.
+in your `LOGGING` settings. The exact setup depends on whether you use
+a structured logging library such as [`structlog`].
+
+See {doc}`logging` for more information.
 
 ## Startup actions
 
@@ -227,3 +230,4 @@ postgres' LISTEN/NOTIFY that integrate with Django. For instance,
 [open an issue]: https://github.com/procrastinate-org/procrastinate/issues
 [this talk at djangocon 2019]: https://www.youtube.com/watch?v=_DIlE-yc9ZQ
 [`AppConfig.ready()`]: https://docs.djangoproject.com/en/5.0/ref/applications/#django.apps.AppConfig.ready
+[`structlog`]: https://www.structlog.org/en/stable/

--- a/docs/howto/logging.md
+++ b/docs/howto/logging.md
@@ -18,8 +18,17 @@ class ProcrastinateLogFilter(logging.Filter):
 logging.getLogger("procrastinate").addFilter(ProcrastinateLogFilter)
 ```
 
-We'll try to document what attribute is available on each log, but one common thing is
-the "action" attribute, that describes the event that triggered the logging. You can
+One extra attribute that should be common to all procrastinate logs is
+`action` attribute, that describes the event that triggered the logging. You can
 match on this.
 
+By default, extra attributes are not shown in the log output. The easiest way
+to see them is to use a structured logging library such as [`structlog`].
+
+If you want a minimal example of a logging setup that displays the extra
+attributes without using third party logging libraries, look at the
+[Django demo]
+
 [extra]: https://timber.io/blog/the-pythonic-guide-to-logging/#adding-context
+[`structlog`]: https://www.structlog.org/en/stable/
+[Django demo]: https://github.com/procrastinate-org/procrastinate/blob/main/procrastinate_demos/demo_django/project/settings.py#L151

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -168,6 +168,15 @@ class Blueprint:
             task.blueprint = self
         blueprint.tasks = new_tasks
 
+        logger.info(
+            "Adding tasks from blueprint",
+            extra={
+                "action": "loading_blueprint",
+                "namespace": namespace,
+                "tasks": [t.name for t in new_tasks.values()],
+            },
+        )
+
         # Add the namespaced tasks to this namespace
         self.tasks.update(new_tasks)
 

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -234,8 +234,8 @@ class Worker:
     def find_task(self, task_name: str) -> tasks.Task:
         try:
             return self.app.tasks[task_name]
-        except KeyError:
-            raise exceptions.TaskNotFound
+        except KeyError as exc:
+            raise exceptions.TaskNotFound from exc
 
     async def run_job(self, job: jobs.Job, worker_id: int) -> None:
         task_name = job.task_name

--- a/procrastinate_demos/demo_django/demo/tasks.py
+++ b/procrastinate_demos/demo_django/demo/tasks.py
@@ -4,6 +4,7 @@ import time
 
 from django.db import transaction
 
+from procrastinate import App, Blueprint
 from procrastinate.contrib.django import app
 
 from .models import Book
@@ -18,7 +19,16 @@ def index_book(book_id: int):
     set_indexed.defer(book_id=book_id)
 
 
-@app.task(queue="index")
+# Showcasing a task using blueprints. This is not mandatory at all.
+# The blueprint is loaded in PROCRASTINATE_ON_APP_READY
+blueprint = Blueprint()
+
+
+@blueprint.task(queue="index")
 async def set_indexed(book_id: int):
     # Async ORM call
     await Book.objects.filter(id=book_id).aupdate(indexed=True)
+
+
+def on_app_ready(app: App):
+    app.add_tasks_from(blueprint, namespace="bp")


### PR DESCRIPTION
Relates to #934

- Blueprints log a little bit more
- Django demo uses blueprints
- Django demo logs extra params
- Documentation details a bit more how to achieve that

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [x] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
