### PR TITLE
Make procrastinate.contrib.django.app a proxy

### DIFF
--- a/procrastinate/contrib/django/__init__.py
+++ b/procrastinate/contrib/django/__init__.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from typing import cast
-
-from procrastinate import app as app_module
-
-from .placeholder import FutureApp
+from .procrastinate_app import app
 from .router import ProcrastinateReadOnlyRouter
 from .utils import connector_params
 
@@ -14,10 +10,3 @@ __all__ = [
     "ProcrastinateReadOnlyRouter",
 ]
 default_app_config = "procrastinate.contrib.django.apps.ProcrastinateConfig"
-
-# Before the Django app is ready, we're defining the app as a blueprint so
-# that tasks can be registered. The real app will be initialized in the
-# ProcrastinateConfig.ready() method.
-# This blueprint has special implementations for App method so that if
-# users try to use the app before it's ready, they get a helpful error message.
-app: app_module.App = cast(app_module.App, FutureApp())

--- a/procrastinate/contrib/django/apps.py
+++ b/procrastinate/contrib/django/apps.py
@@ -6,10 +6,8 @@ from django import apps
 from django.utils import module_loading
 
 import procrastinate
-from procrastinate.contrib import django as contrib_django
-from procrastinate.contrib.django import migrations_magic, utils
 
-from . import django_connector
+from . import django_connector, migrations_magic, procrastinate_app, utils
 
 
 class ProcrastinateConfig(apps.AppConfig):
@@ -18,11 +16,13 @@ class ProcrastinateConfig(apps.AppConfig):
 
     def ready(self) -> None:
         migrations_magic.load()
-        contrib_django.app = create_app(blueprint=contrib_django.app)
+        procrastinate_app._current_app = create_app(
+            blueprint=procrastinate_app._current_app
+        )
 
     @property
     def app(self) -> procrastinate.App:
-        return contrib_django.app
+        return procrastinate_app.app
 
 
 def get_import_paths() -> Iterable[str]:

--- a/procrastinate/contrib/django/procrastinate_app.py
+++ b/procrastinate/contrib/django/procrastinate_app.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import functools
+from typing import NoReturn, cast
+
+from procrastinate import app as app_module
+from procrastinate import blueprints
+
+from . import exceptions
+
+
+def _not_ready(_method: str, *args, **kwargs) -> NoReturn:
+    base_text = (
+        f"Cannot call procrastinate.contrib.app.{_method}() before "
+        "the 'procrastinate.contrib.django' django app is ready."
+    )
+    details = (
+        "If this message appears at import time, the app is not ready yet: "
+        "move the corresponding code in an app's `AppConfig.ready()` method. "
+        "If this message appears in an app's `AppConfig.ready()` method, "
+        'make sure `"procrastinate.contrib.django"` appears before '
+        "that app when ordering apps in the Django setting `INSTALLED_APPS`. "
+        "Alternatively, use the Django setting "
+        "PROCRASTINATE_ON_APP_READY (see the doc)."
+    )
+    raise exceptions.DjangoNotReady(base_text + "\n\n" + details)
+
+
+class FutureApp(blueprints.Blueprint):
+    _shadowed_methods = frozenset(
+        [
+            "__enter__",
+            "__exit__",
+            "_register_builtin_tasks",
+            "_worker",
+            "check_connection_async",
+            "check_connection",
+            "close_async",
+            "close",
+            "configure_task",
+            "open_async",
+            "open",
+            "perform_import_paths",
+            "run_worker_async",
+            "run_worker",
+            "schema_manager",
+            "with_connector",
+            "will_configure_task",
+        ]
+    )
+    for method in _shadowed_methods:
+        locals()[method] = functools.partial(_not_ready, method)
+
+
+class ProxyApp:
+    def __repr__(self) -> str:
+        return repr(_current_app)
+
+    def __getattr__(self, name):
+        return getattr(_current_app, name)
+
+
+# Users may import the app before it's ready, so we're defining a proxy
+# that references either the pre-app or the real app.
+app: app_module.App = cast(app_module.App, ProxyApp())
+
+# Before the Django app is ready, we're defining the app as a blueprint so
+# that tasks can be registered. The real app will be initialized in the
+# ProcrastinateConfig.ready() method.
+# This blueprint has special implementations for App methods so that if
+# users try to use the app before it's ready, they get a helpful error message.
+_current_app: app_module.App = cast(app_module.App, FutureApp())

--- a/tests/unit/contrib/django/test_placeholder.py
+++ b/tests/unit/contrib/django/test_placeholder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from procrastinate import app, blueprints
-from procrastinate.contrib.django import exceptions, placeholder
+from procrastinate.contrib.django import exceptions, procrastinate_app
 
 
 def test__not_ready():
@@ -15,16 +15,16 @@ def test__not_ready():
         exceptions.DjangoNotReady,
         match=message,
     ):
-        placeholder._not_ready("foo")
+        procrastinate_app._not_ready("foo")
 
 
 def test_FutureApp__not_ready():
     with pytest.raises(exceptions.DjangoNotReady):
-        placeholder.FutureApp().open()
+        procrastinate_app.FutureApp().open()
 
 
 def test_FutureApp__defer():
-    app = placeholder.FutureApp()
+    app = procrastinate_app.FutureApp()
 
     @app.task
     def foo():
@@ -38,4 +38,4 @@ def test_FutureApp__shadowed_methods():
     ignored = {"from_path"}
     added = {"will_configure_task"}
     app_methods = set(dir(app.App)) - set(dir(blueprints.Blueprint)) - ignored | added
-    assert sorted(placeholder.FutureApp._shadowed_methods) == sorted(app_methods)
+    assert sorted(procrastinate_app.FutureApp._shadowed_methods) == sorted(app_methods)


### PR DESCRIPTION
Make procrastinate.contrib.django.app a proxy so that we use the same instance before and after it's ready

Relates to #934.

I don't think we need to talk about it in the doc.
I'm not sure what kind of test would make sense.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
