### PR TITLE
Fix warnings, and enable warnings as errors in CI

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1341,6 +1341,22 @@ files = [
 sqlalchemy = "*"
 
 [[package]]
+name = "setuptools"
+version = "69.2.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-69.2.0-py3-none-any.whl", hash = "sha256:c21c49fb1042386df081cb5d86759792ab89efca84cf114889191cd09aacc80c"},
+    {file = "setuptools-69.2.0.tar.gz", hash = "sha256:0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.2)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1813,4 +1829,4 @@ sqlalchemy = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "89182fdb47dd1dc57dafe323c483140a995fe0f3b1f5dd76025c805f668f3b10"
+content-hash = "a24d4cf663211fbee4c8d940fbb80363f7ec6ab5b8721e7dd353e0aa84bf55c3"

--- a/procrastinate/metadata.py
+++ b/procrastinate/metadata.py
@@ -8,9 +8,9 @@ def extract_metadata() -> Mapping[str, str]:
     metadata = importlib_metadata.metadata("procrastinate")
 
     return {
-        "author": metadata["Author"],
-        "email": metadata["Author-email"],
-        "license": metadata["License"],
-        "url": metadata["Home-page"],
-        "version": metadata["Version"],
+        "author": metadata.get("Author", ""),
+        "email": metadata.get("Author-email", ""),
+        "license": metadata.get("License", ""),
+        "url": metadata.get("Home-page", ""),
+        "version": metadata.get("Version", ""),
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ pytest-cov = "*"
 pytest-django = "*"
 pytest-mock = "*"
 migra = "*"
+# migra depends on schemainspect, which has an implicit dependency on setuptools
+# (pkg_resources).
+setuptools = { version = "*", python = ">=3.12" }
 
 [tool.poetry.group.docs.dependencies]
 django = ">=2.2"
@@ -103,7 +106,10 @@ testpaths = [
     "tests/acceptance",
     "tests/migration",
 ]
-filterwarnings = ""
+filterwarnings = """
+    error
+    ignore:unclosed.+:ResourceWarning
+"""
 asyncio_mode = "auto"
 DJANGO_SETTINGS_MODULE = "tests.acceptance.django_settings"
 

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -284,7 +284,9 @@ async def test_finish_job_wrong_end_status(
 async def test_retry_job(pg_job_manager, fetched_job_factory):
     job1 = await fetched_job_factory(queue="queue_a")
 
-    await pg_job_manager.retry_job(job=job1, retry_at=datetime.datetime.utcnow())
+    await pg_job_manager.retry_job(
+        job=job1, retry_at=datetime.datetime.now(datetime.timezone.utc)
+    )
 
     job2 = await pg_job_manager.fetch_job(queues=None)
 
@@ -480,23 +482,12 @@ async def test_list_tasks_dict(fixture_jobs, pg_job_manager):
     }
 
 
-async def test_list_locks_dict(fixture_jobs, job_factory, pg_job_manager):
-    pg_job_manager.defer_job_async(
-        job=job_factory(
-            queue="q3",
-            lock=None,
-            queueing_lock="queueing_lock3",
-            task_name="task_foo",
-            task_kwargs={"key": "a"},
-        )
-    )
-    assert (await pg_job_manager.list_locks_async())[0] == {
-        "name": "lock1",
-        "jobs_count": 1,
-        "todo": 1,
-        "doing": 0,
-        "succeeded": 0,
-        "failed": 0,
+async def test_list_locks_dict(fixture_jobs, pg_job_manager):
+    assert {e["name"] for e in await pg_job_manager.list_locks_async()} == {
+        "lock1",
+        "lock2",
+        "lock3",
+        "lock4",
     }
 
 

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -2,15 +2,25 @@ from __future__ import annotations
 
 import contextlib
 import pathlib
+import warnings
 
 import pytest
 from django.core import management
 from django.db import connection
-from migra import Migration
 from sqlalchemy.pool import NullPool
 from sqlbag import S
 
 from procrastinate import psycopg_connector, schema
+
+with warnings.catch_warnings(record=True):
+    # migra uses schemainspect which uses pkg_resources which is deprecated
+    warnings.filterwarnings(
+        action="ignore", category=DeprecationWarning, module="pkg_resources"
+    )
+    warnings.filterwarnings(
+        action="ignore", category=DeprecationWarning, module="schemainspect"
+    )
+    from migra import Migration
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #979 

Fixes (or ignore) all existing warnings
Make CI crash on new warnings

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
