### PR TITLE
Redo wrap_exception and add one for the Django Connector

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -286,6 +286,17 @@ files = [
 ]
 
 [[package]]
+name = "contextlib2"
+version = "21.6.0"
+description = "Backports and enhancements for the contextlib module"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "contextlib2-21.6.0-py2.py3-none-any.whl", hash = "sha256:3fbdb64466afd23abaf6c977627b75b6139a5a3e8ce38405c5b413aed7a0471f"},
+    {file = "contextlib2-21.6.0.tar.gz", hash = "sha256:ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869"},
+]
+
+[[package]]
 name = "coverage"
 version = "7.4.4"
 description = "Code coverage measurement for Python"
@@ -1829,4 +1840,4 @@ sqlalchemy = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a24d4cf663211fbee4c8d940fbb80363f7ec6ab5b8721e7dd353e0aa84bf55c3"
+content-hash = "050bd48624b2d48e761d3bfb650c0649936f4cfdae6672bdbdaad9daceb9595b"

--- a/procrastinate/contrib/aiopg/aiopg_connector.py
+++ b/procrastinate/contrib/aiopg/aiopg_connector.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import functools
 import logging
 from typing import Any, AsyncGenerator, Callable, Coroutine, Iterable
@@ -21,7 +20,7 @@ logger = logging.getLogger(__name__)
 CoroutineFunction = Callable[..., Coroutine]
 
 
-@contextlib.asynccontextmanager
+@utils.async_context_decorator
 async def wrap_exceptions() -> AsyncGenerator[None, None]:
     """
     Wrap psycopg2 and aiopg errors as connector exceptions.

--- a/procrastinate/contrib/aiopg/aiopg_connector.py
+++ b/procrastinate/contrib/aiopg/aiopg_connector.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import logging
-from typing import Any, Callable, Coroutine, Iterable
+from typing import Any, AsyncGenerator, Callable, Coroutine, Iterable
 
 import aiopg
 import psycopg2
@@ -20,26 +21,19 @@ logger = logging.getLogger(__name__)
 CoroutineFunction = Callable[..., Coroutine]
 
 
-def wrap_exceptions(coro: CoroutineFunction) -> CoroutineFunction:
+@contextlib.asynccontextmanager
+async def wrap_exceptions() -> AsyncGenerator[None, None]:
     """
     Wrap psycopg2 and aiopg errors as connector exceptions.
 
     This decorator is expected to be used on coroutine functions only.
     """
-
-    @functools.wraps(coro)
-    async def wrapped(*args, **kwargs):
-        try:
-            return await coro(*args, **kwargs)
-        except psycopg2.errors.UniqueViolation as exc:
-            raise exceptions.UniqueViolation(constraint_name=exc.diag.constraint_name)
-        except psycopg2.Error as exc:
-            raise exceptions.ConnectorException from exc
-
-    # Attaching a custom attribute to ease testability and make the
-    # decorator more introspectable
-    wrapped._exceptions_wrapped = True  # type: ignore
-    return wrapped
+    try:
+        yield
+    except psycopg2.errors.UniqueViolation as exc:
+        raise exceptions.UniqueViolation(constraint_name=exc.diag.constraint_name)
+    except psycopg2.Error as exc:
+        raise exceptions.ConnectorException from exc
 
 
 def wrap_query_exceptions(coro: CoroutineFunction) -> CoroutineFunction:
@@ -167,7 +161,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
         """
         base_on_connect = pool_args.pop("on_connect", None)
 
-        @wrap_exceptions
+        @wrap_exceptions()
         async def on_connect(connection):
             if base_on_connect:
                 await base_on_connect(connection)
@@ -201,7 +195,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
         else:
             self._pool = await self._create_pool(self._pool_args)
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def _create_pool(self, pool_args: dict[str, Any]) -> aiopg.Pool:
         if self._sync_connector is not None:
             await utils.sync_to_async(self._sync_connector.close)
@@ -209,7 +203,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
 
         return await aiopg.create_pool(**pool_args)
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def close_async(self) -> None:
         """
         Close the pool and awaits all connections to be released.
@@ -246,13 +240,13 @@ class AiopgConnector(connector.BaseAsyncConnector):
     # Because of this, it's easier to have 2 distinct methods for executing from
     # a pool or from a connection
 
-    @wrap_exceptions
+    @wrap_exceptions()
     @wrap_query_exceptions
     async def execute_query_async(self, query: str, **arguments: Any) -> None:
         with await self.pool.cursor() as cursor:
             await cursor.execute(query, self._wrap_json(arguments))
 
-    @wrap_exceptions
+    @wrap_exceptions()
     @wrap_query_exceptions
     async def _execute_query_connection(
         self, query: str, connection: aiopg.Connection, **arguments: Any
@@ -260,7 +254,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
         async with connection.cursor() as cursor:
             await cursor.execute(query, self._wrap_json(arguments))
 
-    @wrap_exceptions
+    @wrap_exceptions()
     @wrap_query_exceptions
     async def execute_query_one_async(
         self, query: str, **arguments: Any
@@ -270,7 +264,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
 
             return await cursor.fetchone()
 
-    @wrap_exceptions
+    @wrap_exceptions()
     @wrap_query_exceptions
     async def execute_query_all_async(
         self, query: str, **arguments: Any
@@ -288,7 +282,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
             }
         )
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def listen_notify(
         self, event: asyncio.Event, channels: Iterable[str]
     ) -> None:
@@ -315,7 +309,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
                 event.set()
                 await self._loop_notify(event=event, connection=connection)
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def _loop_notify(
         self,
         event: asyncio.Event,

--- a/procrastinate/psycopg_connector.py
+++ b/procrastinate/psycopg_connector.py
@@ -38,7 +38,7 @@ else:
 logger = logging.getLogger(__name__)
 
 
-@contextlib.asynccontextmanager
+@utils.async_context_decorator
 async def wrap_exceptions() -> AsyncGenerator[None, None]:
     with sync_psycopg_connector.wrap_exceptions():
         yield

--- a/procrastinate/psycopg_connector.py
+++ b/procrastinate/psycopg_connector.py
@@ -2,20 +2,18 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import functools
 import logging
 from typing import (
     TYPE_CHECKING,
     Any,
+    AsyncGenerator,
     AsyncIterator,
     Callable,
-    Coroutine,
     Iterable,
-    TypeVar,
     cast,
 )
 
-from typing_extensions import LiteralString, ParamSpec
+from typing_extensions import LiteralString
 
 from procrastinate import connector, exceptions, sql, sync_psycopg_connector, utils
 
@@ -39,32 +37,11 @@ else:
 
 logger = logging.getLogger(__name__)
 
-T = TypeVar("T")
-P = ParamSpec("P")
 
-
-def wrap_exceptions(
-    coro: Callable[P, Coroutine[None, Any, T]],
-) -> Callable[P, Coroutine[None, Any, T]]:
-    """
-    Wrap psycopg errors as connector exceptions.
-
-    This decorator is expected to be used on coroutine functions only.
-    """
-
-    @functools.wraps(coro)
-    async def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
-        try:
-            return await coro(*args, **kwargs)
-        except psycopg.errors.UniqueViolation as exc:
-            raise exceptions.UniqueViolation(constraint_name=exc.diag.constraint_name)
-        except psycopg.Error as exc:
-            raise exceptions.ConnectorException from exc
-
-    # Attaching a custom attribute to ease testability and make the
-    # decorator more introspectable
-    wrapped._exceptions_wrapped = True  # type: ignore
-    return wrapped
+@contextlib.asynccontextmanager
+async def wrap_exceptions() -> AsyncGenerator[None, None]:
+    with sync_psycopg_connector.wrap_exceptions():
+        yield
 
 
 class PsycopgConnector(connector.BaseAsyncConnector):
@@ -162,7 +139,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
             await self._async_pool.open(wait=True)  # type: ignore
 
     @staticmethod
-    @wrap_exceptions
+    @wrap_exceptions()
     async def _create_pool(
         pool_args: dict[str, Any],
     ) -> psycopg_pool.AsyncConnectionPool:
@@ -177,7 +154,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
             check=psycopg_pool.AsyncConnectionPool.check_connection,
         )
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def close_async(self) -> None:
         """
         Close the pool and awaits all connections to be released.
@@ -209,12 +186,12 @@ class PsycopgConnector(connector.BaseAsyncConnector):
                     )
                 yield cursor
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def execute_query_async(self, query: LiteralString, **arguments: Any) -> None:
         async with self._get_cursor() as cursor:
             await cursor.execute(query, self._wrap_json(arguments))
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def execute_query_one_async(
         self, query: LiteralString, **arguments: Any
     ) -> dict[str, Any]:
@@ -227,7 +204,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
                 raise exceptions.NoResult
             return result
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def execute_query_all_async(
         self, query: LiteralString, **arguments: Any
     ) -> list[dict[str, Any]]:
@@ -245,7 +222,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
             **{key: psycopg.sql.Identifier(value) for key, value in identifiers.items()}
         )
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def listen_notify(
         self, event: asyncio.Event, channels: Iterable[str]
     ) -> None:
@@ -265,7 +242,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
                 event.set()
                 await self._loop_notify(event=event, connection=connection)
 
-    @wrap_exceptions
+    @wrap_exceptions()
     async def _loop_notify(
         self,
         event: asyncio.Event,

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import datetime
 import importlib
 import inspect
 import logging
 import pathlib
+import sys
 import types
 from typing import (
     Any,
@@ -423,3 +425,12 @@ async def gen_with_timeout(
                 raise
             else:
                 return
+
+
+def async_context_decorator(func: Callable) -> Callable:
+    if sys.version_info < (3, 10):
+        import contextlib2
+
+        return contextlib2.asynccontextmanager(func)
+    else:
+        return contextlib.asynccontextmanager(func)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ aiopg = { version = "*", optional = true }
 anyio = "*"
 asgiref = "*"
 attrs = "*"
+contextlib2 = { version = "*", python = "<3.10" }
 croniter = "*"
 django = { version = ">=2.2", optional = true }
 importlib-metadata = { version = "*", python = "<3.8" }

--- a/tests/unit/contrib/aiopg/test_aiopg_connector.py
+++ b/tests/unit/contrib/aiopg/test_aiopg_connector.py
@@ -41,7 +41,7 @@ async def test_adapt_pool_args_on_connect(mocker):
     ],
 )
 async def test_wrap_exceptions_wraps(exc_type, expected_type):
-    @aiopg_connector.wrap_exceptions
+    @aiopg_connector.wrap_exceptions()
     async def corofunc():
         raise exc_type
 
@@ -52,7 +52,7 @@ async def test_wrap_exceptions_wraps(exc_type, expected_type):
 
 
 async def test_wrap_exceptions_success():
-    @aiopg_connector.wrap_exceptions
+    @aiopg_connector.wrap_exceptions()
     async def corofunc(a, b):
         return a, b
 
@@ -143,7 +143,7 @@ async def test_wrap_query_exceptions_success(mocker):
     ],
 )
 def test_wrap_exceptions_applied(method_name, connector):
-    assert getattr(connector, method_name)._exceptions_wrapped is True
+    assert hasattr(getattr(connector, method_name), "__wrapped__")
 
 
 async def test_listen_notify_pool_one_connection(mocker, caplog, connector):

--- a/tests/unit/contrib/psycopg2/test_psycopg2_connector.py
+++ b/tests/unit/contrib/psycopg2/test_psycopg2_connector.py
@@ -8,7 +8,7 @@ from procrastinate.contrib.psycopg2 import psycopg2_connector
 
 
 def test_wrap_exceptions_wraps():
-    @psycopg2_connector.wrap_exceptions
+    @psycopg2_connector.wrap_exceptions()
     def func():
         raise psycopg2.DatabaseError
 
@@ -17,7 +17,7 @@ def test_wrap_exceptions_wraps():
 
 
 def test_wrap_exceptions_success():
-    @psycopg2_connector.wrap_exceptions
+    @psycopg2_connector.wrap_exceptions()
     def func(a, b):
         return a, b
 
@@ -88,7 +88,7 @@ def test_wrap_query_exceptions_success(mocker):
 )
 def test_wrap_exceptions_applied(method_name):
     connector = psycopg2_connector.Psycopg2Connector()
-    assert getattr(connector, method_name)._exceptions_wrapped is True
+    assert hasattr(getattr(connector, method_name), "__wrapped__")
 
 
 @pytest.fixture

--- a/tests/unit/contrib/sqlalchemy/test_psycopg2_connector.py
+++ b/tests/unit/contrib/sqlalchemy/test_psycopg2_connector.py
@@ -11,7 +11,7 @@ from procrastinate.contrib.sqlalchemy import (
 
 
 def test_wrap_exceptions_wraps():
-    @sqlalchemy_psycopg2_connector.wrap_exceptions
+    @sqlalchemy_psycopg2_connector.wrap_exceptions()
     def func():
         raise sqlalchemy.exc.OperationalError(
             statement="SELECT 1", params={}, orig=psycopg2.DatabaseError()
@@ -25,7 +25,7 @@ def test_wrap_exceptions_unique_violation(mocker):
     class UniqueViolation(psycopg2.errors.UniqueViolation):
         diag = None
 
-    @sqlalchemy_psycopg2_connector.wrap_exceptions
+    @sqlalchemy_psycopg2_connector.wrap_exceptions()
     def func():
         exc = UniqueViolation()
         exc.diag = mocker.Mock(constraint_name="constraint name")
@@ -38,7 +38,7 @@ def test_wrap_exceptions_unique_violation(mocker):
 
 
 def test_wrap_exceptions_integrity_error_not_unique(mocker):
-    @sqlalchemy_psycopg2_connector.wrap_exceptions
+    @sqlalchemy_psycopg2_connector.wrap_exceptions()
     def func():
         exc = Exception()
         exc.diag = mocker.Mock(constraint_name="constraint name")
@@ -49,7 +49,7 @@ def test_wrap_exceptions_integrity_error_not_unique(mocker):
 
 
 def test_wrap_exceptions_success():
-    @sqlalchemy_psycopg2_connector.wrap_exceptions
+    @sqlalchemy_psycopg2_connector.wrap_exceptions()
     def func(a, b):
         return a, b
 
@@ -127,7 +127,7 @@ def test_wrap_query_exceptions_success(mocker):
 )
 def test_wrap_exceptions_applied(method_name):
     connector = sqlalchemy_psycopg2_connector.SQLAlchemyPsycopg2Connector()
-    assert getattr(connector, method_name)._exceptions_wrapped is True
+    assert hasattr(getattr(connector, method_name), "__wrapped__")
 
 
 @pytest.fixture

--- a/tests/unit/test_psycopg_connector.py
+++ b/tests/unit/test_psycopg_connector.py
@@ -12,7 +12,7 @@ def connector():
 
 
 async def test_wrap_exceptions_wraps():
-    @psycopg_connector.wrap_exceptions
+    @psycopg_connector.wrap_exceptions()
     async def corofunc():
         raise psycopg.DatabaseError
 
@@ -23,7 +23,7 @@ async def test_wrap_exceptions_wraps():
 
 
 async def test_wrap_exceptions_success():
-    @psycopg_connector.wrap_exceptions
+    @psycopg_connector.wrap_exceptions()
     async def corofunc(a, b):
         return a, b
 
@@ -42,7 +42,7 @@ async def test_wrap_exceptions_success():
     ],
 )
 def test_wrap_exceptions_applied(method_name, connector):
-    assert getattr(connector, method_name)._exceptions_wrapped is True
+    assert hasattr(getattr(connector, method_name), "__wrapped__")
 
 
 async def test_open_async_no_pool_specified(mocker, connector):

--- a/tests/unit/test_sync_psycopg_connector.py
+++ b/tests/unit/test_sync_psycopg_connector.py
@@ -7,7 +7,7 @@ from procrastinate import exceptions, sync_psycopg_connector
 
 
 def test_wrap_exceptions_wraps():
-    @sync_psycopg_connector.wrap_exceptions
+    @sync_psycopg_connector.wrap_exceptions()
     def func():
         raise psycopg.DatabaseError
 
@@ -16,7 +16,7 @@ def test_wrap_exceptions_wraps():
 
 
 def test_wrap_exceptions_success():
-    @sync_psycopg_connector.wrap_exceptions
+    @sync_psycopg_connector.wrap_exceptions()
     def func(a, b):
         return a, b
 
@@ -35,7 +35,7 @@ def test_wrap_exceptions_success():
 )
 def test_wrap_exceptions_applied(method_name):
     connector = sync_psycopg_connector.SyncPsycopgConnector()
-    assert getattr(connector, method_name)._exceptions_wrapped is True
+    assert hasattr(getattr(connector, method_name), "__wrapped__")
 
 
 @pytest.fixture

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -485,3 +485,22 @@ async def test_async_gen_timeout__complete():
         result.append(i)
 
     assert result == [1, 2, 3]
+
+
+async def test_async_context_decorator():
+    result = []
+
+    @utils.async_context_decorator
+    async def func():
+        result.append(1)
+        yield
+        result.append(3)
+
+    @func()
+    async def func2():
+        result.append(2)
+        return 4
+
+    assert await func2() == 4
+
+    assert result == [1, 2, 3]


### PR DESCRIPTION
Closes #981 

Django connector was missing an exception mapper transforming Psycopg (2 or 3) exceptions to procrastinate exception, especially the queueing lock exception that we handle gracefully.

In order to make a proper implementation, I redid `wrap_exceptions` everywhere using `contextlib.contextmanager`.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
