### PR TITLE
Enable using ProcrastinateShell.onecmd from cli shell

### DIFF
--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -6,6 +6,7 @@ import functools
 import json
 import logging
 import os
+import shlex
 import sys
 from typing import Any, Awaitable, Callable, Literal, Union
 
@@ -475,6 +476,12 @@ def configure_shell_parser(subparsers: argparse._SubParsersAction):
         help="Administration shell for procrastinate",
         **parser_options,
     )
+    add_argument(
+        shell_parser,
+        "args",
+        nargs="*",
+        help="Invoke a shell command and exit",
+    )
     shell_parser.set_defaults(func=shell_)
 
 
@@ -627,7 +634,7 @@ async def healthchecks(app: procrastinate.App):
     print("Found procrastinate_jobs table: OK")
 
 
-async def shell_(app: procrastinate.App):
+async def shell_(app: procrastinate.App, args: list[str]):
     """
     Administration shell for procrastinate.
     """
@@ -635,7 +642,10 @@ async def shell_(app: procrastinate.App):
         job_manager=app.job_manager,
     )
 
-    await utils.sync_to_async(shell_obj.cmdloop)
+    if args:
+        await utils.sync_to_async(shell_obj.onecmd, shlex.join(args))
+    else:
+        await utils.sync_to_async(shell_obj.cmdloop)
 
 
 def main():

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -643,7 +643,7 @@ async def shell_(app: procrastinate.App, args: list[str]):
     )
 
     if args:
-        await utils.sync_to_async(shell_obj.onecmd, shlex.join(args))
+        await utils.sync_to_async(shell_obj.onecmd, line=shlex.join(args))
     else:
         await utils.sync_to_async(shell_obj.cmdloop)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import argparse
 import datetime
+import io
 import json
 import logging
-import shlex
 
 import pytest
 
@@ -270,30 +270,35 @@ def test_load_app(mocker):
         cli.load_app("foobar")
 
 
-@pytest.mark.parametrize(
-    "method_name, args",
-    [
-        (
-            "cmdloop",
-            [],
-        ),
-        (
-            "onecmd",
-            ["list_jobs"],
-        ),
-        (
-            "onecmd",
-            ["list_jobs", "--help"],
-        ),
-    ],
-)
-async def test_shell_calls_onecmd_or_cmdloop(mocker, app, method_name, args):
-    mock = mocker.patch(
-        f"procrastinate.shell.ProcrastinateShell.{method_name}", new=mocker.Mock()
-    )
-    await cli.shell_(app, args)
+async def test_shell_single_command(app, capsys):
+    @app.task(name="foobar")
+    def mytask(a):
+        pass
 
-    if args:
-        mock.assert_called_once_with(shlex.join(args))
-    else:
-        mock.assert_called_once_with()
+    await mytask.defer_async(a=1)
+
+    await cli.shell_(app=app, args=["list_jobs"])
+
+    out, _ = capsys.readouterr()
+
+    assert out == "#1 foobar on default - [todo]\n"
+
+
+async def test_shell_interactive_command(app, capsys, mocker):
+    @app.task(name="foobar")
+    def mytask(a):
+        pass
+
+    await mytask.defer_async(a=1)
+
+    mocker.patch("sys.stdin", io.StringIO("list_jobs\nexit\n"))
+
+    await cli.shell_(app=app, args=[])
+
+    out, _ = capsys.readouterr()
+
+    expected = """Welcome to the procrastinate shell.   Type help or ? to list commands.
+
+procrastinate> #1 foobar on default - [todo]
+procrastinate> """
+    assert out == expected


### PR DESCRIPTION
Allows invoking the shell commands without entering the cmdloop

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
