### PR TITLE
test_get_sync_connector__[not]_open as integration test, not unit test

### DIFF
--- a/tests/integration/contrib/aiopg/test_aiopg_connector.py
+++ b/tests/integration/contrib/aiopg/test_aiopg_connector.py
@@ -9,6 +9,7 @@ import attr
 import pytest
 
 from procrastinate.contrib.aiopg import aiopg_connector as aiopg
+from procrastinate.contrib.psycopg2 import psycopg2_connector
 
 
 @pytest.fixture
@@ -267,3 +268,16 @@ async def test_destructor(connection_params, capsys):
     # even by using filterwarnings to turn it into an exception, as
     # Python ignores exceptions that occur in destructors
     del connector
+
+
+async def test_get_sync_connector__open(aiopg_connector):
+    await aiopg_connector.open_async()
+    assert aiopg_connector.get_sync_connector() is aiopg_connector
+    await aiopg_connector.close_async()
+
+
+async def test_get_sync_connector__not_open(connection_params):
+    aiopg_connector = aiopg.AiopgConnector(**connection_params)
+    sync = aiopg_connector.get_sync_connector()
+    assert isinstance(sync, psycopg2_connector.Psycopg2Connector)
+    assert aiopg_connector.get_sync_connector() is sync

--- a/tests/integration/test_psycopg_connector.py
+++ b/tests/integration/test_psycopg_connector.py
@@ -8,7 +8,7 @@ import asgiref.sync
 import attr
 import pytest
 
-from procrastinate import exceptions, psycopg_connector
+from procrastinate import exceptions, psycopg_connector, sync_psycopg_connector
 
 
 @pytest.fixture
@@ -217,3 +217,15 @@ async def test_loop_notify_timeout(psycopg_connector):
         pytest.fail("Failed to detect that connection was closed and stop")
 
     assert not event.is_set()
+
+
+async def test_get_sync_connector__open(psycopg_connector):
+    assert psycopg_connector.get_sync_connector() is psycopg_connector
+    await psycopg_connector.close_async()
+
+
+async def test_get_sync_connector__not_open(not_opened_psycopg_connector):
+    sync = not_opened_psycopg_connector.get_sync_connector()
+    assert isinstance(sync, sync_psycopg_connector.SyncPsycopgConnector)
+    assert not_opened_psycopg_connector.get_sync_connector() is sync
+    assert sync._pool_args == not_opened_psycopg_connector._pool_args

--- a/tests/unit/contrib/aiopg/test_aiopg_connector.py
+++ b/tests/unit/contrib/aiopg/test_aiopg_connector.py
@@ -7,7 +7,6 @@ import pytest
 
 from procrastinate import exceptions
 from procrastinate.contrib.aiopg import aiopg_connector
-from procrastinate.contrib.psycopg2 import psycopg2_connector
 
 
 @pytest.fixture
@@ -198,15 +197,3 @@ async def test_open_async_pool_argument_specified(fake_connector):
 def test_get_pool(connector):
     with pytest.raises(exceptions.AppNotOpen):
         _ = connector.pool
-
-
-async def test_get_sync_connector__open(connector):
-    await connector.open_async()
-    assert connector.get_sync_connector() is connector
-    await connector.close_async()
-
-
-async def test_get_sync_connector__not_open(connector):
-    sync = connector.get_sync_connector()
-    assert isinstance(sync, psycopg2_connector.Psycopg2Connector)
-    assert connector.get_sync_connector() is sync

--- a/tests/unit/test_psycopg_connector.py
+++ b/tests/unit/test_psycopg_connector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import psycopg
 import pytest
 
-from procrastinate import exceptions, psycopg_connector, sync_psycopg_connector
+from procrastinate import exceptions, psycopg_connector
 
 
 @pytest.fixture
@@ -99,16 +99,3 @@ async def test_open_async_pool_factory_argument_specified(mocker):
 def test_get_pool(connector):
     with pytest.raises(exceptions.AppNotOpen):
         _ = connector.pool
-
-
-async def test_get_sync_connector__open(connector):
-    await connector.open_async()
-    assert connector.get_sync_connector() is connector
-    await connector.close_async()
-
-
-async def test_get_sync_connector__not_open(connector):
-    sync = connector.get_sync_connector()
-    assert isinstance(sync, sync_psycopg_connector.SyncPsycopgConnector)
-    assert connector.get_sync_connector() is sync
-    assert sync._pool_args == connector._pool_args


### PR DESCRIPTION
(I had worked on that previously, just pushing a PR to avoid losing the work)

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
