### PR TITLE
improve decorators type annotations

### DIFF
--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -289,13 +289,6 @@ class Blueprint:
         queue: str = jobs.DEFAULT_QUEUE,
         lock: str | None = None,
         queueing_lock: str | None = None,
-    ) -> (
-        Callable[[Callable[P]], Task[P, P]]
-        | Callable[
-            [Callable[Concatenate[JobContext, P]]],
-            Task[Concatenate[JobContext, P], P],
-        ]
-        | Task[P, P]
     ):
         from procrastinate.tasks import Task
 
@@ -369,5 +362,4 @@ class Blueprint:
         )
 
     def will_configure_task(self) -> None:
-        raise exceptions.UnboundTaskError
         raise exceptions.UnboundTaskError

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -9,11 +9,9 @@ from typing_extensions import Concatenate, ParamSpec, Unpack
 
 from procrastinate import exceptions, jobs, periodic, retry, utils
 from procrastinate.job_context import JobContext
-from procrastinate.tasks import ConfigureTaskOptions
 
 if TYPE_CHECKING:
-    from procrastinate import tasks
-    from procrastinate.tasks import Task
+    from procrastinate.tasks import ConfigureTaskOptions, Task
 
 
 logger = logging.getLogger(__name__)
@@ -71,7 +69,7 @@ class Blueprint:
     """
 
     def __init__(self) -> None:
-        self.tasks: dict[str, tasks.Task] = {}
+        self.tasks: dict[str, Task] = {}
         self.periodic_registry = periodic.PeriodicRegistry()
         self._check_stack()
 
@@ -96,7 +94,7 @@ class Blueprint:
                 extra={"action": "app_defined_in___main__"},
             )
 
-    def _register_task(self, task: tasks.Task) -> None:
+    def _register_task(self, task: Task) -> None:
         """
         Register the task into the blueprint task registry.
         Raises exceptions.TaskAlreadyRegistered if the task name
@@ -106,7 +104,7 @@ class Blueprint:
         # Each call to _add_task may raise TaskAlreadyRegistered.
         # We're using an intermediary dict to make sure that if the registration
         # is interrupted midway though, self.tasks is left unmodified.
-        to_add: dict[str, tasks.Task] = {}
+        to_add: dict[str, Task] = {}
         self._add_task(task=task, name=task.name, to=to_add)
 
         for alias in task.aliases:
@@ -114,7 +112,7 @@ class Blueprint:
 
         self.tasks.update(to_add)
 
-    def _add_task(self, task: tasks.Task, name: str, to: dict | None = None) -> None:
+    def _add_task(self, task: Task, name: str, to: dict | None = None) -> None:
         # Add a task to a dict of task while making
         # sure a task of the same name was not already in self.tasks.
         # This lets us prepare a dict of tasks we might add while not adding
@@ -128,7 +126,7 @@ class Blueprint:
         result_dict = self.tasks if to is None else to
         result_dict[name] = task
 
-    def add_task_alias(self, task: tasks.Task, alias: str) -> None:
+    def add_task_alias(self, task: Task, alias: str) -> None:
         """
         Add an alias to a task. This can be useful if a task was in a given
         Blueprint and moves to a different blueprint.

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 Args = ParamSpec("Args")
-"The task arguments passed in when deferring a job"
 P = ParamSpec("P")
-"The decorated function parameters"
 
 
 class TimeDeltaParams(TypedDict):

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -19,12 +19,22 @@ P = ParamSpec("P")
 "The decorated function parameters"
 
 
+class TimeDeltaParams(TypedDict):
+    weeks: NotRequired[int]
+    days: NotRequired[int]
+    hours: NotRequired[int]
+    minutes: NotRequired[int]
+    seconds: NotRequired[int]
+    milliseconds: NotRequired[int]
+    microseconds: NotRequired[int]
+
+
 class ConfigureTaskOptions(TypedDict):
     lock: NotRequired[str | None]
     queueing_lock: NotRequired[str | None]
     task_kwargs: NotRequired[types.JSONDict | None]
     schedule_at: NotRequired[datetime.datetime | None]
-    schedule_in: NotRequired[dict[str, int] | None]
+    schedule_in: NotRequired[TimeDeltaParams | None]
     queue: NotRequired[str | None]
 
 

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import Any, Callable, cast
+from typing import Any, Callable, Generic, TypedDict, cast
+
+from typing_extensions import NotRequired, ParamSpec, Unpack
 
 from procrastinate import app as app_module
 from procrastinate import blueprints, exceptions, jobs, manager, types, utils
@@ -11,31 +13,44 @@ from procrastinate import retry as retry_module
 logger = logging.getLogger(__name__)
 
 
+Args = ParamSpec("Args")
+"The task arguments passed in when deferring a job"
+P = ParamSpec("P")
+"The decorated function parameters"
+
+
+class ConfigureTaskOptions(TypedDict):
+    lock: NotRequired[str | None]
+    queueing_lock: NotRequired[str | None]
+    task_kwargs: NotRequired[types.JSONDict | None]
+    schedule_at: NotRequired[datetime.datetime | None]
+    schedule_in: NotRequired[dict[str, int] | None]
+    queue: NotRequired[str | None]
+
+
 def configure_task(
     *,
     name: str,
     job_manager: manager.JobManager,
-    lock: str | None = None,
-    queueing_lock: str | None = None,
-    task_kwargs: types.JSONDict | None = None,
-    schedule_at: datetime.datetime | None = None,
-    schedule_in: dict[str, int] | None = None,
-    queue: str = jobs.DEFAULT_QUEUE,
+    **options: Unpack[ConfigureTaskOptions],
 ) -> jobs.JobDeferrer:
+    schedule_at = options.get("schedule_at")
+    schedule_in = options.get("schedule_in")
+
     if schedule_at and schedule_in is not None:
         raise ValueError("Cannot set both schedule_at and schedule_in")
 
     if schedule_in is not None:
         schedule_at = utils.utcnow() + datetime.timedelta(**schedule_in)
 
-    task_kwargs = task_kwargs or {}
+    task_kwargs = options.get("task_kwargs") or {}
     return jobs.JobDeferrer(
         job=jobs.Job(
             id=None,
-            lock=lock,
-            queueing_lock=queueing_lock,
+            lock=options.get("lock"),
+            queueing_lock=options.get("queueing_lock"),
             task_name=name,
-            queue=queue,
+            queue=options.get("queue") or jobs.DEFAULT_QUEUE,
             task_kwargs=task_kwargs,
             scheduled_at=schedule_at,
         ),
@@ -43,7 +58,7 @@ def configure_task(
     )
 
 
-class Task:
+class Task(Generic[P, Args]):
     """
     A task is a function that should be executed later. It is linked to a
     default queue, and expects keyword arguments.
@@ -72,7 +87,7 @@ class Task:
 
     def __init__(
         self,
-        func: Callable,
+        func: Callable[P],
         *,
         blueprint: blueprints.Blueprint,
         # task naming
@@ -88,7 +103,7 @@ class Task:
     ):
         self.queue = queue
         self.blueprint = blueprint
-        self.func: Callable = func
+        self.func: Callable[P] = func
         self.aliases = aliases if aliases else []
         self.retry_strategy = retry_module.get_retry_strategy(retry)
         self.name: str = name if name else self.full_path
@@ -106,14 +121,14 @@ class Task:
             for alias in self.aliases
         ]
 
-    def __call__(self, *args, **kwargs: types.JSONValue) -> Any:
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Any:
         return self.func(*args, **kwargs)
 
     @property
     def full_path(self) -> str:
         return utils.get_full_path(self.func)
 
-    async def defer_async(self, **task_kwargs: types.JSONValue) -> int:
+    async def defer_async(self, *_: Args.args, **task_kwargs: Args.kwargs) -> int:
         """
         Create a job from this task and the given arguments.
         The job will be created with default parameters, if you want to better
@@ -121,7 +136,7 @@ class Task:
         """
         return await self.configure().defer_async(**task_kwargs)
 
-    def defer(self, **task_kwargs: types.JSONValue) -> int:
+    def defer(self, *_: Args.args, **task_kwargs: Args.kwargs) -> int:
         """
         Create a job from this task and the given arguments.
         The job will be created with default parameters, if you want to better
@@ -129,16 +144,7 @@ class Task:
         """
         return self.configure().defer(**task_kwargs)
 
-    def configure(
-        self,
-        *,
-        lock: str | None = None,
-        queueing_lock: str | None = None,
-        task_kwargs: types.JSONDict | None = None,
-        schedule_at: datetime.datetime | None = None,
-        schedule_in: dict[str, int] | None = None,
-        queue: str | None = None,
-    ) -> jobs.JobDeferrer:
+    def configure(self, **options: Unpack[ConfigureTaskOptions]) -> jobs.JobDeferrer:
         """
         Configure the job with all the specific settings, defining how the job
         should be launched.
@@ -181,8 +187,14 @@ class Task:
         """
         self.blueprint.will_configure_task()
 
-        app = cast(app_module.App, self.blueprint)
+        lock = options.get("lock")
+        queueing_lock = options.get("queueing_lock")
+        task_kwargs = options.get("task_kwargs")
+        schedule_at = options.get("schedule_at")
+        schedule_in = options.get("schedule_in")
+        queue = options.get("queue")
 
+        app = cast(app_module.App, self.blueprint)
         return configure_task(
             name=self.name,
             job_manager=app.job_manager,

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -17,10 +17,10 @@ def task_func():
 
 def test_app_no_connector():
     with pytest.raises(TypeError):
-        app_module.App()
+        app_module.App()  # type: ignore
 
 
-def test_app_task_dont_read_function_attributes(app):
+def test_app_task_dont_read_function_attributes(app: app_module.App):
     # This is a weird one. It's a regression test. At some point, we noted that,
     # due to the slightly wrong usage of update_wrapper, the attributes on the
     # decorated function were copied on the task. This led to surprising
@@ -33,12 +33,12 @@ def test_app_task_dont_read_function_attributes(app):
     assert task.pass_context is False
 
 
-def test_app_register_builtins(app):
+def test_app_register_builtins(app: app_module.App):
     assert "procrastinate.builtin_tasks.remove_old_jobs" in app.tasks
     assert "builtin:procrastinate.builtin_tasks.remove_old_jobs" in app.tasks
 
 
-def test_app_register(app):
+def test_app_register(app: app_module.App):
     task = tasks.Task(task_func, blueprint=app, queue="queue", name="bla")
 
     app._register_task(task)
@@ -58,7 +58,7 @@ def test_app_worker(app, mocker):
     )
 
 
-def test_app_run_worker(app):
+def test_app_run_worker(app: app_module.App):
     result = []
 
     @app.task
@@ -72,7 +72,7 @@ def test_app_run_worker(app):
     assert result == [1]
 
 
-async def test_app_run_worker_async(app):
+async def test_app_run_worker_async(app: app_module.App):
     result = []
 
     @app.task
@@ -86,7 +86,7 @@ async def test_app_run_worker_async(app):
     assert result == [1]
 
 
-async def test_app_run_worker_async_cancel(app):
+async def test_app_run_worker_async_cancel(app: app_module.App):
     result = []
 
     @app.task
@@ -110,7 +110,7 @@ def test_from_path(mocker):
     load.assert_called_once_with("dotted.path", app_module.App)
 
 
-def test_app_configure_task(app):
+def test_app_configure_task(app: app_module.App):
     scheduled_at = conftest.aware_datetime(2000, 1, 1)
     job = app.configure_task(
         name="my_name",
@@ -127,7 +127,7 @@ def test_app_configure_task(app):
     assert job.task_kwargs == {"a": 1}
 
 
-def test_app_configure_task_unknown_allowed(app):
+def test_app_configure_task_unknown_allowed(app: app_module.App):
     @app.task(name="my_name", queue="bla")
     def my_name(a):
         pass
@@ -144,15 +144,15 @@ def test_app_configure_task_unknown_allowed(app):
     assert job.task_kwargs == {"a": 1}
 
 
-def test_app_configure_task_unkown_not_allowed(app):
+def test_app_configure_task_unkown_not_allowed(app: app_module.App):
     with pytest.raises(exceptions.TaskNotFound):
         app.configure_task(name="my_name", allow_unknown=False)
 
 
-def test_app_periodic(app):
+def test_app_periodic(app: app_module.App):
     @app.periodic(cron="0 * * * 1", periodic_id="foo")
     @app.task
-    def yay(timestamp):
+    def yay(timestamp: int):
         pass
 
     assert len(app.periodic_registry.periodic_tasks) == 1

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -3,22 +3,23 @@ from __future__ import annotations
 import pytest
 
 from procrastinate import tasks, utils
+from procrastinate.app import App
 
 from .. import conftest
 
 
-def task_func():
+def task_func(c: int | None = None):
     pass
 
 
-def test_task_init_with_no_name(app):
+def test_task_init_with_no_name(app: App):
     task = tasks.Task(task_func, blueprint=app, queue="queue")
 
     assert task.func is task_func
     assert task.name == "tests.unit.test_tasks.task_func"
 
 
-async def test_task_defer_async(app, connector):
+async def test_task_defer_async(app: App, connector):
     task = tasks.Task(task_func, blueprint=app, queue="queue")
 
     await task.defer_async(c=3)
@@ -113,4 +114,5 @@ def test_task_get_retry_exception(app, mocker):
 
     exception = ValueError()
     assert task.get_retry_exception(exception=exception, job=job) is mock.return_value
+    mock.assert_called_with(exception=exception, attempts=0)
     mock.assert_called_with(exception=exception, attempts=0)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -8,7 +8,7 @@ from procrastinate.app import App
 from .. import conftest
 
 
-def task_func(c: int | None = None):
+def task_func():
     pass
 
 


### PR DESCRIPTION
Closes #1056 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

This improves typing of the `@App.task` and `@App.periodic` decorators.

### basic task

The `@task` decorator now returns a generic `Task` that defines the `func` and `defer` parameters.

For example, given the task below:
```Python
@app.task
async def sum(a: int, b: int):
    return a + b
```

`sum` is:
```Python
(function) sum: Task[(a: int, b: int), (a: int, b: int)]
```

`[(a: int, b: int)` describes the parameters of the wrapped func while `(a: int, b: int)` describes the parameters of the `defer_async` and `defer` functions. 

⚠️ The Task signature doesn't enforce keyword arguments. Specifying positional arguments when calling `defer` will likely fail but won't be caught by type check. One way to improve type safety is to prevent positional arguments on the decorated function .e.g. `async def sum(*, a: int, b: int)`

### task with context

Another example is the use of the `passContext` option:
```Python
@app.task(pass_context= True)
async def sum(context: JobContext, a: int, b: int):
    return a + b
```

`sum` is:
```Python
(function) sum: Task[(JobContext, a: int, b: int), (a: int, b: int)]
```
This is because `JobContext` is  injected by the worker but should not be part of the `defer` arguments.
The type annotation also correctly complains if the decorated function is missing a first parameter of type`JobContext`.

### Periodic task

Yet another example is the periodic decorator:
```
@app.periodic(cron="0 * * * 1")
@app.task
async def cleanup(timestamp: int):
    pass
```

`cleanup` is
```Python
Task[(timestamp: int), ()]
```
This is because `timestamp` is injected by the decorator but should not be part of the `defer` arguments.  

⚠️ `timestamp` is actually set as a keyword parameter while the type annotation enforces a positional parameter.
Unfortunately, [concatenating keywords parameters is not supported](https://peps.python.org/pep-0612/#concatenating-keyword-parameters).

Examples demonstrating the limitations:
```Python
@app.periodic(cron="0 * * * 1")
@app.task
# This works at runtime but fails type annotation
async def cleanup(what: str, timestamp: int):
    pass
```

```Python
@app.periodic(cron="0 * * * 1")
@app.task
# This fails at runtime but type annotation has no error
async def cleanup(ts: int):
    pass
```

### Other changes

Options supported by both the `task` and `periodic` decorators are fully defined.

### Other comments

The `task_kwargs` keyword parameter from `Task.configure` remains of type `JSONDict`.
I am unsure if this can be accurately typed.

I initially added another generic parameter for the task return type but eventually removed it as I didn't see much value.

I added type hints in some of the test files to demonstrate the type annotations. That said, given `pyright` is configured to ignore the `tests` folder, breaking type hints won't be enforced during CI.
Including type check for all `tests` would have made this pull request much larger, if that is even something desirable. 
Maybe there is a middle ground where some test files are included. I lean on you to suggest the best course of action here.
