### PR TITLE
Failing test for pg_job_manager.delete_old_jobs with psycopg2-based lib

### DIFF
--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -41,7 +41,7 @@ WHERE id IN (
               ON job.id = event.job_id
             ORDER BY job.id, event.at DESC
     ) AS job
-    WHERE job.status = ANY(%(statuses)s)
+    WHERE job.status = ANY(%(statuses)s::procrastinate_job_status[])
       AND (%(queue)s::varchar IS NULL OR job.queue_name = %(queue)s)
       AND latest_at < NOW() - (%(nb_hours)s || 'HOUR')::INTERVAL
 )

--- a/tests/integration/contrib/aiopg/conftest.py
+++ b/tests/integration/contrib/aiopg/conftest.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from procrastinate.contrib.aiopg import aiopg_connector as aiopg
+
+
+@pytest.fixture
+async def aiopg_connector_factory(connection_params):
+    connectors = []
+
+    async def _(*, open: bool = True, **kwargs):
+        json_dumps = kwargs.pop("json_dumps", None)
+        json_loads = kwargs.pop("json_loads", None)
+        connection_params.update(kwargs)
+        connector = aiopg.AiopgConnector(
+            json_dumps=json_dumps, json_loads=json_loads, **connection_params
+        )
+        connectors.append(connector)
+        if open:
+            await connector.open_async()
+        return connector
+
+    yield _
+    for connector in connectors:
+        await connector.close_async()
+
+
+@pytest.fixture
+async def aiopg_connector(aiopg_connector_factory):
+    return await aiopg_connector_factory()

--- a/tests/integration/contrib/aiopg/test_aiopg_connector.py
+++ b/tests/integration/contrib/aiopg/test_aiopg_connector.py
@@ -12,32 +12,6 @@ from procrastinate.contrib.aiopg import aiopg_connector as aiopg
 from procrastinate.contrib.psycopg2 import psycopg2_connector
 
 
-@pytest.fixture
-async def aiopg_connector_factory(connection_params):
-    connectors = []
-
-    async def _(*, open: bool = True, **kwargs):
-        json_dumps = kwargs.pop("json_dumps", None)
-        json_loads = kwargs.pop("json_loads", None)
-        connection_params.update(kwargs)
-        connector = aiopg.AiopgConnector(
-            json_dumps=json_dumps, json_loads=json_loads, **connection_params
-        )
-        connectors.append(connector)
-        if open:
-            await connector.open_async()
-        return connector
-
-    yield _
-    for connector in connectors:
-        await connector.close_async()
-
-
-@pytest.fixture
-async def aiopg_connector(aiopg_connector_factory):
-    return await aiopg_connector_factory()
-
-
 async def test_adapt_pool_args_on_connect(mocker):
     called = []
 

--- a/tests/integration/contrib/aiopg/test_aiopg_job_manager.py
+++ b/tests/integration/contrib/aiopg/test_aiopg_job_manager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+
 import pytest
 
 from procrastinate import manager
@@ -18,6 +20,11 @@ def get_all(aiopg_connector):
         )
 
     return f
+
+
+@pytest.fixture
+def deferred_job_factory(deferred_job_factory, pg_job_manager):
+    return functools.partial(deferred_job_factory, job_manager=pg_job_manager)
 
 
 async def test_delete_old_jobs_job_todo(

--- a/tests/integration/contrib/aiopg/test_aiopg_job_manager.py
+++ b/tests/integration/contrib/aiopg/test_aiopg_job_manager.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from procrastinate import manager
+
+
+@pytest.fixture
+def pg_job_manager(aiopg_connector):
+    return manager.JobManager(connector=aiopg_connector)
+
+
+@pytest.fixture
+def get_all(aiopg_connector):
+    async def f(table, *fields):
+        return await aiopg_connector.execute_query_all_async(
+            f"SELECT {', '.join(fields)} FROM {table}"
+        )
+
+    return f
+
+
+async def test_delete_old_jobs_job_todo(
+    get_all,
+    pg_job_manager,
+    psycopg_connector,
+    deferred_job_factory,
+):
+    job = await deferred_job_factory(queue="queue_a")
+
+    # We fake its started event timestamp
+    await psycopg_connector.execute_query_async(
+        f"UPDATE procrastinate_events SET at=at - INTERVAL '2 hours'"
+        f"WHERE job_id={job.id}"
+    )
+
+    await pg_job_manager.delete_old_jobs(nb_hours=0)
+    assert len(await get_all("procrastinate_jobs", "id")) == 1


### PR DESCRIPTION
Closes #1075 

We didn't test delete_old_jobs with psycopg2. The rewriting of the query for psycopg3 made it incompatible. I'm not 100% surprised that it went so long without being detected, but at least now it's fixed.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
