### PR TITLE
Call configure callback in listen notify

### DIFF
--- a/tests/integration/test_psycopg_connector.py
+++ b/tests/integration/test_psycopg_connector.py
@@ -181,6 +181,16 @@ async def test_listen_notify(psycopg_connector):
         task.cancel()
 
 
+async def test_get_standalone_connection_applies_configure(psycopg_connector_factory):
+    async def configure(connection):
+        connection.attr = "value"
+
+    connector = await psycopg_connector_factory(configure=configure)
+
+    async with connector._get_standalone_connection() as connection:
+        assert connection.attr == "value"
+
+
 async def test_loop_notify_stop_when_connection_closed(psycopg_connector):
     # We want to make sure that the when the connection is closed, the loop end.
     event = asyncio.Event()


### PR DESCRIPTION
Closes #1074 

Now when you provide `configure` callable to `PsycopgConnector` it will also be applied in `PsycopgConnector.listen_notify()`.

Consequently, now you have a way to disable prepared statements on psycopg<3.1: 
```python

def configure(connection):
    # disable prepared statements for connection
    connection.prepare_threshold = None

PsycopgConnector(configure=configure)
```

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
