### PR TITLE
Allow to cancel a job or request an abort

### DIFF
--- a/docs/howto/advanced.md
+++ b/docs/howto/advanced.md
@@ -8,6 +8,7 @@ advanced/context
 advanced/locks
 advanced/schedule
 advanced/priorities
+advanced/cancellation
 advanced/queueing_locks
 advanced/cron
 advanced/retry

--- a/docs/howto/advanced/cancellation.md
+++ b/docs/howto/advanced/cancellation.md
@@ -1,0 +1,71 @@
+# Cancel a job
+
+We can cancel a job that has not yet been processed by a worker. We can also
+mark a job that is currently being processed for abortion, but this request
+has to be handled by the task itself.
+
+## Cancel a job (that is not being processed yet)
+
+```python
+# by using the sync method
+app.job_manager.cancel_job_by_id(33)
+# or by using the async method
+await app.job_manager.cancel_job_by_id_async(33)
+```
+
+## Delete the canceled job
+
+A cancelled job can also be deleted from the database.
+
+```python
+# by using the sync method
+app.job_manager.cancel_job_by_id(33, delete_job=True)
+# or by using the async method
+await app.job_manager.cancel_job_by_id_async(33, delete_job=True)
+```
+
+## Mark a currently being processed job for abortion
+
+If a worker has not picked up the job yet, the below command behaves like the
+command without the `abort` option. But if a job is already in the middle of
+being processed, the `abort` option marks this job for abortion (see below
+how to handle this request).
+
+```python
+# by using the sync method
+app.job_manager.cancel_job_by_id(33, abort=True)
+# or by using the async method
+await app.job_manager.cancel_job_by_id_async(33, abort=True)
+```
+
+## Handle a abortion request inside the task
+
+In our task, we can check (for example, periodically) if the task should be
+aborted. If we want to respect that request (we don't have to), we raise a
+`JobAborted` error.
+
+```python
+@app.task(pass_context=True)
+def my_task(context):
+  for i in range(100):
+    if context.should_abort():
+      raise exceptions.JobAborted
+    do_something_expensive()
+```
+
+There is also an async API
+
+```python
+@app.task(pass_context=True)
+async def my_task(context):
+  for i in range(100):
+    if await context.should_abort_async():
+      raise exceptions.JobAborted
+    do_something_expensive()
+```
+
+:::{warning}
+`context.should_abort()` and `context.should_abort_async()` does poll the
+database and might flood the database. Ensure you do it only sometimes and
+not from too many parallel tasks.
+:::

--- a/docs/howto/advanced/cancellation.md
+++ b/docs/howto/advanced/cancellation.md
@@ -42,7 +42,8 @@ await app.job_manager.cancel_job_by_id_async(33, abort=True)
 
 In our task, we can check (for example, periodically) if the task should be
 aborted. If we want to respect that request (we don't have to), we raise a
-`JobAborted` error.
+`JobAborted` error. Any message passed to `JobAborted` (e.g.
+`raise JobAborted("custom message")`) will end up in the logs.
 
 ```python
 @app.task(pass_context=True)

--- a/docs/howto/advanced/cancellation.md
+++ b/docs/howto/advanced/cancellation.md
@@ -13,7 +13,7 @@ app.job_manager.cancel_job_by_id(33)
 await app.job_manager.cancel_job_by_id_async(33)
 ```
 
-## Delete the canceled job
+## Delete the cancelled job
 
 A cancelled job can also be deleted from the database.
 

--- a/procrastinate/contrib/django/migrations/0028_add_cancel_states.py
+++ b/procrastinate/contrib/django/migrations/0028_add_cancel_states.py
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
                     ("failed", "failed"),
                     ("succeeded", "succeeded"),
                     ("cancelled", "cancelled"),
-                    ("request_to_abort", "request_to_abort"),
+                    ("abort_requested", "abort_requested"),
                     ("aborted", "aborted"),
                     ("scheduled", "scheduled"),
                 ],

--- a/procrastinate/contrib/django/migrations/0028_add_cancel_states.py
+++ b/procrastinate/contrib/django/migrations/0028_add_cancel_states.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+
+from .. import migrations_utils
+
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations_utils.RunProcrastinateSQL(name="02.06.00_01_add_cancel_states.sql"),
+        migrations.AlterField(
+            "procrastinatejob",
+            "status",
+            models.CharField(
+                choices=[
+                    ("todo", "todo"),
+                    ("doing", "doing"),
+                    ("succeeded", "succeeded"),
+                    ("failed", "failed"),
+                    ("cancelled", "cancelled"),
+                    ("aborting", "aborting"),
+                    ("aborted", "aborted"),
+                ],
+                max_length=32,
+            ),
+        ),
+        migrations.AlterField(
+            "procrastinateevent",
+            "type",
+            models.CharField(
+                choices=[
+                    ("deferred", "deferred"),
+                    ("started", "started"),
+                    ("deferred_for_retry", "deferred_for_retry"),
+                    ("failed", "failed"),
+                    ("succeeded", "succeeded"),
+                    ("cancelled", "cancelled"),
+                    ("request_to_abort", "request_to_abort"),
+                    ("aborted", "aborted"),
+                    ("scheduled", "scheduled"),
+                ],
+                max_length=32,
+            ),
+        ),
+    ]
+    name = "0028_add_cancel_states"
+    dependencies = [("procrastinate", "0027_add_periodic_job_priority")]

--- a/procrastinate/contrib/django/models.py
+++ b/procrastinate/contrib/django/models.py
@@ -64,6 +64,9 @@ class ProcrastinateJob(ProcrastinateReadOnlyModelMixin, models.Model):
         "doing",
         "succeeded",
         "failed",
+        "cancelled",
+        "aborting",
+        "aborted",
     )
     id = models.BigAutoField(primary_key=True)
     queue_name = models.CharField(max_length=128)
@@ -91,6 +94,8 @@ class ProcrastinateEvent(ProcrastinateReadOnlyModelMixin, models.Model):
         "failed",
         "succeeded",
         "cancelled",
+        "request_to_abort",
+        "aborted",
         "scheduled",
     )
     id = models.BigAutoField(primary_key=True)

--- a/procrastinate/contrib/django/models.py
+++ b/procrastinate/contrib/django/models.py
@@ -94,7 +94,7 @@ class ProcrastinateEvent(ProcrastinateReadOnlyModelMixin, models.Model):
         "failed",
         "succeeded",
         "cancelled",
-        "request_to_abort",
+        "abort_requested",
         "aborted",
         "scheduled",
     )

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -63,6 +63,12 @@ class JobError(ProcrastinateException):
         self.critical = critical
 
 
+class JobAborted(ProcrastinateException):
+    """
+    Job was aborted (usually as reaction to an abortion request).
+    """
+
+
 class AppNotOpen(ProcrastinateException):
     """
     App was not open. Procrastinate App needs to be opened using:

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -65,7 +65,7 @@ class JobError(ProcrastinateException):
 
 class JobAborted(ProcrastinateException):
     """
-    Job was aborted (usually as reaction to an abortion request).
+    Job was aborted.
     """
 
 

--- a/procrastinate/job_context.py
+++ b/procrastinate/job_context.py
@@ -101,3 +101,21 @@ class JobContext:
             message += "no current job"
 
         return message
+
+    def should_abort(self) -> bool:
+        assert self.app
+        assert self.job
+        assert self.job.id
+
+        job_id = self.job.id
+        status = self.app.job_manager.get_job_status(job_id)
+        return status == jobs.Status.ABORTING
+
+    async def should_abort_async(self) -> bool:
+        assert self.app
+        assert self.job
+        assert self.job.id
+
+        job_id = self.job.id
+        status = await self.app.job_manager.get_job_status_async(job_id)
+        return status == jobs.Status.ABORTING

--- a/procrastinate/jobs.py
+++ b/procrastinate/jobs.py
@@ -38,7 +38,7 @@ class Status(Enum):
     DOING = "doing"  #: A worker is running the job
     SUCCEEDED = "succeeded"  #: The job ended successfully
     FAILED = "failed"  #: The job ended with an error
-    CANCELLED = "cancelled"  #: The job was canceled
+    CANCELLED = "cancelled"  #: The job was cancelled
     ABORTING = "aborting"  #: The job is requested to be aborted
     ABORTED = "aborted"  #: The job was aborted
 

--- a/procrastinate/jobs.py
+++ b/procrastinate/jobs.py
@@ -38,6 +38,9 @@ class Status(Enum):
     DOING = "doing"  #: A worker is running the job
     SUCCEEDED = "succeeded"  #: The job ended successfully
     FAILED = "failed"  #: The job ended with an error
+    CANCELLED = "cancelled"  #: The job was canceled
+    ABORTING = "aborting"  #: The job is requested to be aborted
+    ABORTED = "aborted"  #: The job was aborted
 
 
 @attr.dataclass(frozen=True, kw_only=True)

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -253,8 +253,8 @@ class JobManager:
             The id of the job to cancel
         abort : ``bool``
             If True, a job in ``doing`` state will be marked as ``aborting``, but the task
-            itself has to respect the abortion request. If False, only jobs in ``todo`` state
-            will be set to ``cancelled`` and won't be processed by a worker anymore.
+            itself has to respect the abortion request. If False, only jobs in ``todo``
+            state will be set to ``cancelled`` and won't be processed by a worker anymore.
         delete_job : ``bool``
             If True, the job will be deleted from the database after being cancelled. Does
             not affect the jobs that should be aborted.
@@ -262,7 +262,8 @@ class JobManager:
         Returns
         -------
         ``bool``
-            True if the job to be cancelled was found, False otherwise.
+            True if the job to be cancelled (or to mark for abortion) was found. False if
+            no job with that ID or in a state to be cancelled was found.
         """
         result = self.connector.get_sync_connector().execute_query_one(
             query=sql.queries["cancel_job"],
@@ -270,7 +271,12 @@ class JobManager:
             abort=abort,
             delete_job=delete_job,
         )
-        return result["id"] is not None
+
+        if result["id"] is None:
+            return False
+
+        assert result["id"] == job_id
+        return True
 
     async def cancel_job_by_id_async(
         self, job_id: int, abort: bool = False, delete_job=False
@@ -284,8 +290,8 @@ class JobManager:
             The id of the job to cancel
         abort : ``bool``
             If True, a job in ``doing`` state will be marked as ``aborting``, but the task
-            itself has to respect the abortion request. If False, only jobs in ``todo`` state
-            will be set to ``cancelled`` and won't be processed by a worker anymore.
+            itself has to respect the abortion request. If False, only jobs in ``todo``
+            state will be set to ``cancelled`` and won't be processed by a worker anymore.
         delete_job : ``bool``
             If True, the job will be deleted from the database after being cancelled. Does
             not affect the jobs that should be aborted.
@@ -293,7 +299,8 @@ class JobManager:
         Returns
         -------
         ``bool``
-            True if the job to be cancelled was found, False otherwise.
+            True if the job to be cancelled (or to mark for abortion) was found. False if
+            no job with that ID or in a state to be cancelled was found.
         """
         result = await self.connector.execute_query_one_async(
             query=sql.queries["cancel_job"],
@@ -301,7 +308,12 @@ class JobManager:
             abort=abort,
             delete_job=delete_job,
         )
-        return result["id"] is not None
+
+        if result["id"] is None:
+            return False
+
+        assert result["id"] == job_id
+        return True
 
     def get_job_status(self, job_id: int) -> jobs.Status:
         """

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -262,8 +262,9 @@ class JobManager:
         Returns
         -------
         ``bool``
-            True if the job to be cancelled (or to mark for abortion) was found. False if
-            no job with that ID or in a state to be cancelled was found.
+            If True, the job was cancelled (or its abortion was requested). If False,
+            nothing was done: either there is no job with this id or it's not in a state
+            where it may be cancelled (i.e. `todo` or `doing`)
         """
         result = self.connector.get_sync_connector().execute_query_one(
             query=sql.queries["cancel_job"],
@@ -299,8 +300,9 @@ class JobManager:
         Returns
         -------
         ``bool``
-            True if the job to be cancelled (or to mark for abortion) was found. False if
-            no job with that ID or in a state to be cancelled was found.
+            If True, the job was cancelled (or its abortion was requested). If False,
+            nothing was done: either there is no job with this id or it's not in a state
+            where it may be cancelled (i.e. `todo` or `doing`)
         """
         result = await self.connector.execute_query_one_async(
             query=sql.queries["cancel_job"],
@@ -416,7 +418,7 @@ class JobManager:
         defer operation is seen.
 
         This coroutine either returns ``None`` upon calling if it cannot start
-        listening or does not return and needs to be canceled to end.
+        listening or does not return and needs to be cancelled to end.
 
         Parameters
         ----------

--- a/procrastinate/shell.py
+++ b/procrastinate/shell.py
@@ -87,7 +87,10 @@ class ProcrastinateShell(cmd.Cmd):
                 f"todo: {queue['todo']}, "
                 f"doing: {queue['doing']}, "
                 f"succeeded: {queue['succeeded']}, "
-                f"failed: {queue['failed']})"
+                f"failed: {queue['failed']}, "
+                f"cancelled: {queue['cancelled']}, "
+                f"aborting: {queue['aborting']}, "
+                f"aborted: {queue['aborted']})"
             )
 
     def do_list_tasks(self, arg: str) -> None:
@@ -107,7 +110,10 @@ class ProcrastinateShell(cmd.Cmd):
                 f"todo: {task['todo']}, "
                 f"doing: {task['doing']}, "
                 f"succeeded: {task['succeeded']}, "
-                f"failed: {task['failed']})"
+                f"failed: {task['failed']}, "
+                f"cancelled: {task['cancelled']}, "
+                f"aborting: {task['aborting']}, "
+                f"aborted: {task['aborted']})"
             )
 
     def do_list_locks(self, arg: str) -> None:
@@ -127,7 +133,10 @@ class ProcrastinateShell(cmd.Cmd):
                 f"todo: {lock['todo']}, "
                 f"doing: {lock['doing']}, "
                 f"succeeded: {lock['succeeded']}, "
-                f"failed: {lock['failed']})"
+                f"failed: {lock['failed']}, "
+                f"cancelled: {lock['cancelled']}, "
+                f"aborting: {lock['aborting']}, "
+                f"aborted: {lock['aborted']})"
             )
 
     def do_retry(self, arg: str) -> None:
@@ -159,12 +168,7 @@ class ProcrastinateShell(cmd.Cmd):
         Example: cancel 3
         """
         job_id = int(arg)
-        self.async_to_sync(
-            self.job_manager.finish_job_by_id_async,
-            job_id=job_id,
-            status=jobs.Status.FAILED,
-            delete_job=False,
-        )
+        self.job_manager.cancel_job_by_id(job_id=job_id)
 
         (job,) = self.async_to_sync(self.job_manager.list_jobs_async, id=job_id)
         print_job(job)

--- a/procrastinate/sql/migrations/02.06.00_01_add_cancel_states.sql
+++ b/procrastinate/sql/migrations/02.06.00_01_add_cancel_states.sql
@@ -1,0 +1,115 @@
+ALTER TYPE procrastinate_job_status ADD VALUE 'cancelled';
+ALTER TYPE procrastinate_job_status ADD VALUE 'aborting';
+ALTER TYPE procrastinate_job_status ADD VALUE 'aborted';
+
+ALTER TYPE procrastinate_job_event_type ADD VALUE 'request_to_abort' BEFORE 'scheduled';
+ALTER TYPE procrastinate_job_event_type ADD VALUE 'aborted' BEFORE 'scheduled';
+
+CREATE FUNCTION procrastinate_cancel_job(job_id bigint, abort boolean, delete_job boolean)
+    RETURNS bigint
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    _job_id bigint;
+BEGIN
+    IF delete_job THEN
+        DELETE FROM procrastinate_jobs
+        WHERE id = job_id AND status = 'todo'
+        RETURNING id INTO _job_id;
+    END IF;
+    IF _job_id IS NULL THEN
+        IF abort THEN
+            UPDATE procrastinate_jobs
+            SET status = CASE
+                WHEN status = 'todo' THEN 'cancelled'::procrastinate_job_status
+                WHEN status = 'doing' THEN 'aborting'::procrastinate_job_status
+            END
+            WHERE id = job_id AND status IN ('todo', 'doing')
+            RETURNING id INTO _job_id;
+        ELSE
+            UPDATE procrastinate_jobs
+            SET status = 'cancelled'::procrastinate_job_status
+            WHERE id = job_id AND status = 'todo'
+            RETURNING id INTO _job_id;
+        END IF;
+    END IF;
+    RETURN _job_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION procrastinate_finish_job(job_id bigint, end_status procrastinate_job_status, delete_job boolean)
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    _job_id bigint;
+BEGIN
+    IF end_status NOT IN ('succeeded', 'failed', 'aborted') THEN
+        RAISE 'End status should be either "succeeded", "failed" or "aborted" (job id: %)', job_id;
+    END IF;
+    IF delete_job THEN
+        DELETE FROM procrastinate_jobs
+        WHERE id = job_id AND status IN ('todo', 'doing', 'aborting')
+        RETURNING id INTO _job_id;
+    ELSE
+        UPDATE procrastinate_jobs
+        SET status = end_status,
+            attempts =
+                CASE
+                    WHEN status = 'doing' THEN attempts + 1
+                    ELSE attempts
+                END
+        WHERE id = job_id AND status IN ('todo', 'doing', 'aborting')
+        RETURNING id INTO _job_id;
+    END IF;
+    IF _job_id IS NULL THEN
+        RAISE 'Job was not found or not in "doing", "todo" or "aborting" status (job id: %)', job_id;
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION procrastinate_trigger_status_events_procedure_update()
+    RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    WITH t AS (
+        SELECT CASE
+            WHEN OLD.status = 'todo'::procrastinate_job_status
+                AND NEW.status = 'doing'::procrastinate_job_status
+                THEN 'started'::procrastinate_job_event_type
+            WHEN OLD.status = 'doing'::procrastinate_job_status
+                AND NEW.status = 'todo'::procrastinate_job_status
+                THEN 'deferred_for_retry'::procrastinate_job_event_type
+            WHEN OLD.status = 'doing'::procrastinate_job_status
+                AND NEW.status = 'failed'::procrastinate_job_status
+                THEN 'failed'::procrastinate_job_event_type
+            WHEN OLD.status = 'doing'::procrastinate_job_status
+                AND NEW.status = 'succeeded'::procrastinate_job_status
+                THEN 'succeeded'::procrastinate_job_event_type
+            WHEN OLD.status = 'todo'::procrastinate_job_status
+                AND (
+                    NEW.status = 'cancelled'::procrastinate_job_status
+                    OR NEW.status = 'failed'::procrastinate_job_status
+                    OR NEW.status = 'succeeded'::procrastinate_job_status
+                )
+                THEN 'cancelled'::procrastinate_job_event_type
+            WHEN OLD.status = 'doing'::procrastinate_job_status
+                AND NEW.status = 'aborting'::procrastinate_job_status
+                THEN 'request_to_abort'::procrastinate_job_event_type
+            WHEN (
+                    OLD.status = 'doing'::procrastinate_job_status
+                    OR OLD.status = 'aborting'::procrastinate_job_status
+                )
+                AND NEW.status = 'aborted'::procrastinate_job_status
+                THEN 'aborted'::procrastinate_job_event_type
+            ELSE NULL
+        END as event_type
+    )
+    INSERT INTO procrastinate_events(job_id, type)
+        SELECT NEW.id, t.event_type
+        FROM t
+        WHERE t.event_type IS NOT NULL;
+	RETURN NEW;
+END;
+$$;

--- a/procrastinate/sql/migrations/02.06.00_01_add_cancel_states.sql
+++ b/procrastinate/sql/migrations/02.06.00_01_add_cancel_states.sql
@@ -37,6 +37,44 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION procrastinate_fetch_job(
+    target_queue_names character varying[]
+)
+    RETURNS procrastinate_jobs
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+	found_jobs procrastinate_jobs;
+BEGIN
+    WITH candidate AS (
+        SELECT jobs.*
+            FROM procrastinate_jobs AS jobs
+            WHERE
+                -- reject the job if its lock has earlier jobs
+                NOT EXISTS (
+                    SELECT 1
+                        FROM procrastinate_jobs AS earlier_jobs
+                        WHERE
+                            jobs.lock IS NOT NULL
+                            AND earlier_jobs.lock = jobs.lock
+                            AND earlier_jobs.status IN ('todo', 'doing', 'aborting')
+                            AND earlier_jobs.id < jobs.id)
+                AND jobs.status = 'todo'
+                AND (target_queue_names IS NULL OR jobs.queue_name = ANY( target_queue_names ))
+                AND (jobs.scheduled_at IS NULL OR jobs.scheduled_at <= now())
+            ORDER BY jobs.priority DESC, jobs.id ASC LIMIT 1
+            FOR UPDATE OF jobs SKIP LOCKED
+    )
+    UPDATE procrastinate_jobs
+        SET status = 'doing'
+        FROM candidate
+        WHERE procrastinate_jobs.id = candidate.id
+        RETURNING procrastinate_jobs.* INTO found_jobs;
+
+	RETURN found_jobs;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION procrastinate_finish_job(job_id bigint, end_status procrastinate_job_status, delete_job boolean)
     RETURNS void
     LANGUAGE plpgsql

--- a/procrastinate/sql/migrations/02.06.00_01_add_cancel_states.sql
+++ b/procrastinate/sql/migrations/02.06.00_01_add_cancel_states.sql
@@ -20,9 +20,9 @@ BEGIN
     IF _job_id IS NULL THEN
         IF abort THEN
             UPDATE procrastinate_jobs
-            SET status = CASE
-                WHEN status = 'todo' THEN 'cancelled'::procrastinate_job_status
-                WHEN status = 'doing' THEN 'aborting'::procrastinate_job_status
+            SET status = CASE status
+                WHEN 'todo' THEN 'cancelled'::procrastinate_job_status
+                WHEN 'doing' THEN 'aborting'::procrastinate_job_status
             END
             WHERE id = job_id AND status IN ('todo', 'doing')
             RETURNING id INTO _job_id;

--- a/procrastinate/sql/migrations/02.06.00_01_add_cancel_states.sql
+++ b/procrastinate/sql/migrations/02.06.00_01_add_cancel_states.sql
@@ -2,7 +2,7 @@ ALTER TYPE procrastinate_job_status ADD VALUE 'cancelled';
 ALTER TYPE procrastinate_job_status ADD VALUE 'aborting';
 ALTER TYPE procrastinate_job_status ADD VALUE 'aborted';
 
-ALTER TYPE procrastinate_job_event_type ADD VALUE 'request_to_abort' BEFORE 'scheduled';
+ALTER TYPE procrastinate_job_event_type ADD VALUE 'abort_requested' BEFORE 'scheduled';
 ALTER TYPE procrastinate_job_event_type ADD VALUE 'aborted' BEFORE 'scheduled';
 
 CREATE FUNCTION procrastinate_cancel_job(job_id bigint, abort boolean, delete_job boolean)
@@ -96,7 +96,7 @@ BEGIN
                 THEN 'cancelled'::procrastinate_job_event_type
             WHEN OLD.status = 'doing'::procrastinate_job_status
                 AND NEW.status = 'aborting'::procrastinate_job_status
-                THEN 'request_to_abort'::procrastinate_job_event_type
+                THEN 'abort_requested'::procrastinate_job_event_type
             WHEN (
                     OLD.status = 'doing'::procrastinate_job_status
                     OR OLD.status = 'aborting'::procrastinate_job_status

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -50,6 +50,14 @@ WHERE id IN (
 -- Finish a job, changing it from "doing" to "succeeded" or "failed"
 SELECT procrastinate_finish_job(%(job_id)s, %(status)s, %(delete_job)s);
 
+-- cancel_job --
+-- Cancel a job, changing it from "todo" to "cancelled" or from "doing" to "aborting"
+SELECT procrastinate_cancel_job(%(job_id)s, %(abort)s, %(delete_job)s) AS id;
+
+-- get_job_status --
+-- Get the status of a job
+SELECT status FROM procrastinate_jobs WHERE id = %(job_id)s;
+
 -- retry_job --
 -- Retry a job, changing it from "doing" to "todo"
 SELECT procrastinate_retry_job(%(job_id)s, %(retry_at)s);

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -175,7 +175,7 @@ BEGIN
                         WHERE
                             jobs.lock IS NOT NULL
                             AND earlier_jobs.lock = jobs.lock
-                            AND earlier_jobs.status IN ('todo', 'doing')
+                            AND earlier_jobs.status IN ('todo', 'doing', 'aborting')
                             AND earlier_jobs.id < jobs.id)
                 AND jobs.status = 'todo'
                 AND (target_queue_names IS NULL OR jobs.queue_name = ANY( target_queue_names ))

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -21,7 +21,7 @@ CREATE TYPE procrastinate_job_event_type AS ENUM (
     'failed',  -- doing or aborting -> failed
     'succeeded',  -- doing or aborting -> succeeded
     'cancelled', -- todo -> cancelled
-    'request_to_abort', -- doing -> aborting
+    'abort_requested', -- doing -> aborting
     'aborted', -- doing or aborting -> aborted
     'scheduled' -- not an event transition, but recording when a task is scheduled for
 );
@@ -328,7 +328,7 @@ BEGIN
                 THEN 'cancelled'::procrastinate_job_event_type
             WHEN OLD.status = 'doing'::procrastinate_job_status
                 AND NEW.status = 'aborting'::procrastinate_job_status
-                THEN 'request_to_abort'::procrastinate_job_event_type
+                THEN 'abort_requested'::procrastinate_job_event_type
             WHEN (
                     OLD.status = 'doing'::procrastinate_job_status
                     OR OLD.status = 'aborting'::procrastinate_job_status

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -8,16 +8,21 @@ CREATE TYPE procrastinate_job_status AS ENUM (
     'todo',  -- The job is queued
     'doing',  -- The job has been fetched by a worker
     'succeeded',  -- The job ended successfully
-    'failed'  -- The job ended with an error
+    'failed',  -- The job ended with an error
+    'cancelled', -- The job was cancelled
+    'aborting',  -- The job was requested to abort
+    'aborted'  -- The job was aborted
 );
 
 CREATE TYPE procrastinate_job_event_type AS ENUM (
     'deferred',  -- Job created, in todo
     'started',  -- todo -> doing
     'deferred_for_retry',  -- doing -> todo
-    'failed',  -- doing -> failed
-    'succeeded',  -- doing -> succeeded
-    'cancelled', -- todo -> failed or succeeded
+    'failed',  -- doing or aborting -> failed
+    'succeeded',  -- doing or aborting -> succeeded
+    'cancelled', -- todo -> cancelled
+    'request_to_abort', -- doing -> aborting
+    'aborted', -- doing or aborting -> aborted
     'scheduled' -- not an event transition, but recording when a task is scheduled for
 );
 
@@ -198,12 +203,12 @@ AS $$
 DECLARE
     _job_id bigint;
 BEGIN
-    IF end_status NOT IN ('succeeded', 'failed') THEN
-        RAISE 'End status should be either "succeeded" or "failed" (job id: %)', job_id;
+    IF end_status NOT IN ('succeeded', 'failed', 'aborted') THEN
+        RAISE 'End status should be either "succeeded", "failed" or "aborted" (job id: %)', job_id;
     END IF;
     IF delete_job THEN
         DELETE FROM procrastinate_jobs
-        WHERE id = job_id AND status IN ('todo', 'doing')
+        WHERE id = job_id AND status IN ('todo', 'doing', 'aborting')
         RETURNING id INTO _job_id;
     ELSE
         UPDATE procrastinate_jobs
@@ -213,12 +218,44 @@ BEGIN
                     WHEN status = 'doing' THEN attempts + 1
                     ELSE attempts
                 END
-        WHERE id = job_id AND status IN ('todo', 'doing')
+        WHERE id = job_id AND status IN ('todo', 'doing', 'aborting')
         RETURNING id INTO _job_id;
     END IF;
     IF _job_id IS NULL THEN
-        RAISE 'Job was not found or not in "doing" or "todo" status (job id: %)', job_id;
+        RAISE 'Job was not found or not in "doing", "todo" or "aborting" status (job id: %)', job_id;
     END IF;
+END;
+$$;
+
+CREATE FUNCTION procrastinate_cancel_job(job_id bigint, abort boolean, delete_job boolean)
+    RETURNS bigint
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    _job_id bigint;
+BEGIN
+    IF delete_job THEN
+        DELETE FROM procrastinate_jobs
+        WHERE id = job_id AND status = 'todo'
+        RETURNING id INTO _job_id;
+    END IF;
+    IF _job_id IS NULL THEN
+        IF abort THEN
+            UPDATE procrastinate_jobs
+            SET status = CASE
+                WHEN status = 'todo' THEN 'cancelled'::procrastinate_job_status
+                WHEN status = 'doing' THEN 'aborting'::procrastinate_job_status
+            END
+            WHERE id = job_id AND status IN ('todo', 'doing')
+            RETURNING id INTO _job_id;
+        ELSE
+            UPDATE procrastinate_jobs
+            SET status = 'cancelled'::procrastinate_job_status
+            WHERE id = job_id AND status = 'todo'
+            RETURNING id INTO _job_id;
+        END IF;
+    END IF;
+    RETURN _job_id;
 END;
 $$;
 
@@ -284,10 +321,20 @@ BEGIN
                 THEN 'succeeded'::procrastinate_job_event_type
             WHEN OLD.status = 'todo'::procrastinate_job_status
                 AND (
-                    NEW.status = 'failed'::procrastinate_job_status
+                    NEW.status = 'cancelled'::procrastinate_job_status
+                    OR NEW.status = 'failed'::procrastinate_job_status
                     OR NEW.status = 'succeeded'::procrastinate_job_status
                 )
                 THEN 'cancelled'::procrastinate_job_event_type
+            WHEN OLD.status = 'doing'::procrastinate_job_status
+                AND NEW.status = 'aborting'::procrastinate_job_status
+                THEN 'request_to_abort'::procrastinate_job_event_type
+            WHEN (
+                    OLD.status = 'doing'::procrastinate_job_status
+                    OR OLD.status = 'aborting'::procrastinate_job_status
+                )
+                AND NEW.status = 'aborted'::procrastinate_job_status
+                THEN 'aborted'::procrastinate_job_event_type
             ELSE NULL
         END as event_type
     )

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -242,9 +242,9 @@ BEGIN
     IF _job_id IS NULL THEN
         IF abort THEN
             UPDATE procrastinate_jobs
-            SET status = CASE
-                WHEN status = 'todo' THEN 'cancelled'::procrastinate_job_status
-                WHEN status = 'doing' THEN 'aborting'::procrastinate_job_status
+            SET status = CASE status
+                WHEN 'todo' THEN 'cancelled'::procrastinate_job_status
+                WHEN 'doing' THEN 'aborting'::procrastinate_job_status
             END
             WHERE id = job_id AND status IN ('todo', 'doing')
             RETURNING id INTO _job_id;

--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import asyncio
+import time
+
 import pytest
 
 from procrastinate import app as app_module
 from procrastinate.contrib import aiopg
+from procrastinate.exceptions import JobAborted
+from procrastinate.jobs import Status
 
 
 @pytest.fixture(params=["psycopg_connector", "aiopg_connector"])
@@ -39,3 +44,83 @@ async def test_defer(async_app):
 
     assert sum_results == [3, 7, 11]
     assert product_results == [12]
+
+
+async def test_cancel(async_app):
+    sum_results = []
+
+    @async_app.task(queue="default", name="sum_task")
+    async def sum_task(a, b):
+        sum_results.append(a + b)
+
+    job_id = await sum_task.defer_async(a=1, b=2)
+    await sum_task.defer_async(a=3, b=4)
+
+    await async_app.job_manager.cancel_job_by_id_async(job_id)
+
+    status = await async_app.job_manager.get_job_status_async(job_id)
+    assert status == Status.CANCELLED
+
+    jobs = await async_app.job_manager.list_jobs_async()
+    assert len(jobs) == 2
+
+    await async_app.run_worker_async(queues=["default"], wait=False)
+
+    assert sum_results == [7]
+
+
+async def test_cancel_with_delete(async_app):
+    sum_results = []
+
+    @async_app.task(queue="default", name="sum_task")
+    async def sum_task(a, b):
+        sum_results.append(a + b)
+
+    job_id = await sum_task.defer_async(a=1, b=2)
+    await sum_task.defer_async(a=3, b=4)
+
+    await async_app.job_manager.cancel_job_by_id_async(job_id, delete_job=True)
+
+    jobs = await async_app.job_manager.list_jobs_async()
+    assert len(jobs) == 1
+
+    await async_app.run_worker_async(queues=["default"], wait=False)
+
+    assert sum_results == [7]
+
+
+async def test_abort(async_app):
+    @async_app.task(queue="default", name="task1", pass_context=True)
+    async def task1(context):
+        while True:
+            await asyncio.sleep(1)
+            if await context.should_abort_async():
+                raise JobAborted
+
+    @async_app.task(queue="default", name="task2", pass_context=True)
+    def task2(context):
+        while True:
+            time.sleep(1)
+            if context.should_abort():
+                raise JobAborted
+
+    job1_id = await task1.defer_async()
+    job2_id = await task2.defer_async()
+
+    worker_task = asyncio.create_task(
+        async_app.run_worker_async(queues=["default"], wait=False)
+    )
+
+    await asyncio.sleep(1)
+    await async_app.job_manager.cancel_job_by_id_async(job1_id, abort=True)
+
+    await asyncio.sleep(1)
+    await async_app.job_manager.cancel_job_by_id_async(job2_id, abort=True)
+
+    await worker_task
+
+    status = await async_app.job_manager.get_job_status_async(job1_id)
+    assert status == Status.ABORTED
+
+    status = await async_app.job_manager.get_job_status_async(job2_id)
+    assert status == Status.ABORTED

--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -93,14 +93,14 @@ async def test_abort(async_app):
     @async_app.task(queue="default", name="task1", pass_context=True)
     async def task1(context):
         while True:
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.1)
             if await context.should_abort_async():
                 raise JobAborted
 
     @async_app.task(queue="default", name="task2", pass_context=True)
     def task2(context):
         while True:
-            time.sleep(1)
+            time.sleep(0.1)
             if context.should_abort():
                 raise JobAborted
 
@@ -111,10 +111,10 @@ async def test_abort(async_app):
         async_app.run_worker_async(queues=["default"], wait=False)
     )
 
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.1)
     await async_app.job_manager.cancel_job_by_id_async(job1_id, abort=True)
 
-    await asyncio.sleep(1)
+    await asyncio.sleep(0.1)
     await async_app.job_manager.cancel_job_by_id_async(job2_id, abort=True)
 
     await worker_task

--- a/tests/acceptance/test_shell.py
+++ b/tests/acceptance/test_shell.py
@@ -67,44 +67,48 @@ async def test_shell(read, write, defer):
     defer("increment_task", ["--lock=b"], a=5)
 
     await write("cancel 2")
-    assert await read() == ["#2 ns:tests.acceptance.app.sum_task on default - [failed]"]
+    assert await read() == [
+        "#2 ns:tests.acceptance.app.sum_task on default - [cancelled]"
+    ]
 
     await write("cancel 3")
-    assert await read() == ["#3 ns:tests.acceptance.app.sum_task on other - [failed]"]
+    assert await read() == [
+        "#3 ns:tests.acceptance.app.sum_task on other - [cancelled]"
+    ]
 
     await write("cancel 4")
     assert await read() == [
-        "#4 tests.acceptance.app.increment_task on default - [failed]"
+        "#4 tests.acceptance.app.increment_task on default - [cancelled]"
     ]
 
     await write("list_jobs")
     assert await read() == [
         "#1 ns:tests.acceptance.app.sum_task on default - [todo]",
-        "#2 ns:tests.acceptance.app.sum_task on default - [failed]",
-        "#3 ns:tests.acceptance.app.sum_task on other - [failed]",
-        "#4 tests.acceptance.app.increment_task on default - [failed]",
+        "#2 ns:tests.acceptance.app.sum_task on default - [cancelled]",
+        "#3 ns:tests.acceptance.app.sum_task on other - [cancelled]",
+        "#4 tests.acceptance.app.increment_task on default - [cancelled]",
     ]
 
     await write("list_jobs queue=other details")
     assert await read() == [
-        "#3 ns:tests.acceptance.app.sum_task on other - [failed] (attempts=0, priority=0, scheduled_at=None, args={'a': 1, 'b': 2}, lock=lock)",
+        "#3 ns:tests.acceptance.app.sum_task on other - [cancelled] (attempts=0, priority=0, scheduled_at=None, args={'a': 1, 'b': 2}, lock=lock)",
     ]
 
     await write("list_queues")
     assert await read() == [
-        "default: 3 jobs (todo: 1, doing: 0, succeeded: 0, failed: 2)",
-        "other: 1 jobs (todo: 0, doing: 0, succeeded: 0, failed: 1)",
+        "default: 3 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 2, aborting: 0, aborted: 0)",
+        "other: 1 jobs (todo: 0, doing: 0, succeeded: 0, failed: 0, cancelled: 1, aborting: 0, aborted: 0)",
     ]
 
     await write("list_tasks")
     assert await read() == [
-        "ns:tests.acceptance.app.sum_task: 3 jobs (todo: 1, doing: 0, succeeded: 0, failed: 2)",
-        "tests.acceptance.app.increment_task: 1 jobs (todo: 0, doing: 0, succeeded: 0, failed: 1)",
+        "ns:tests.acceptance.app.sum_task: 3 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 2, aborting: 0, aborted: 0)",
+        "tests.acceptance.app.increment_task: 1 jobs (todo: 0, doing: 0, succeeded: 0, failed: 0, cancelled: 1, aborting: 0, aborted: 0)",
     ]
 
     await write("list_locks")
     assert await read() == [
-        "a: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
-        "b: 1 jobs (todo: 0, doing: 0, succeeded: 0, failed: 1)",
-        "lock: 2 jobs (todo: 0, doing: 0, succeeded: 0, failed: 2)",
+        "a: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
+        "b: 1 jobs (todo: 0, doing: 0, succeeded: 0, failed: 0, cancelled: 1, aborting: 0, aborted: 0)",
+        "lock: 2 jobs (todo: 0, doing: 0, succeeded: 0, failed: 0, cancelled: 2, aborting: 0, aborted: 0)",
     ]

--- a/tests/acceptance/test_sync.py
+++ b/tests/acceptance/test_sync.py
@@ -4,6 +4,7 @@ import pytest
 
 import procrastinate
 from procrastinate.contrib import psycopg2
+from procrastinate.jobs import Status
 
 
 @pytest.fixture(params=["sync_psycopg_connector", "psycopg2_connector"])
@@ -51,3 +52,28 @@ async def test_defer(sync_app, async_app):
 
     assert sum_results == [3, 7, 11]
     assert product_results == [12]
+
+
+async def test_cancel(sync_app, async_app):
+    sum_results = []
+
+    @sync_app.task(queue="default", name="sum_task")
+    def sum_task(a, b):
+        sum_results.append(a + b)
+
+    job_id = sum_task.defer(a=1, b=2)
+    sum_task.defer(a=3, b=4)
+
+    sync_app.job_manager.cancel_job_by_id(job_id)
+
+    status = sync_app.job_manager.get_job_status(job_id)
+    assert status == Status.CANCELLED
+
+    jobs = sync_app.job_manager.list_jobs()
+    assert len(jobs) == 2
+
+    # We need to run the async app to execute the tasks
+    async_app.tasks = sync_app.tasks
+    await async_app.run_worker_async(queues=["default"], wait=False)
+
+    assert sum_results == [7]

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -261,7 +261,7 @@ async def test_finish_job_wrong_initial_status(
         await pg_job_manager.finish_job(
             job=job, status=jobs.Status.FAILED, delete_job=delete_job
         )
-    assert 'Job was not found or not in "doing" or "todo" status' in str(
+    assert 'Job was not found or not in "doing", "todo" or "aborting" status' in str(
         excinfo.value.__cause__
     )
 
@@ -276,7 +276,7 @@ async def test_finish_job_wrong_end_status(
         await pg_job_manager.finish_job(
             job=job, status=jobs.Status.TODO, delete_job=delete_job
         )
-    assert 'End status should be either "succeeded" or "failed"' in str(
+    assert 'End status should be either "succeeded", "failed" or "aborted"' in str(
         excinfo.value.__cause__
     )
 
@@ -452,6 +452,9 @@ async def test_list_queues_dict(fixture_jobs, pg_job_manager):
         "doing": 0,
         "succeeded": 0,
         "failed": 1,
+        "cancelled": 0,
+        "aborting": 0,
+        "aborted": 0,
     }
 
 
@@ -479,6 +482,9 @@ async def test_list_tasks_dict(fixture_jobs, pg_job_manager):
         "doing": 1,
         "succeeded": 0,
         "failed": 1,
+        "cancelled": 0,
+        "aborting": 0,
+        "aborted": 0,
     }
 
 

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -79,6 +79,16 @@ async def test_fetch_job_not_fetching_locked_job(
     assert await pg_job_manager.fetch_job(queues=None) is None
 
 
+async def test_fetch_job_respect_lock_aborting_job(
+    pg_job_manager, deferred_job_factory, fetched_job_factory
+):
+    job = await fetched_job_factory(lock="lock_1")
+    await deferred_job_factory(lock="lock_1")
+
+    await pg_job_manager.cancel_job_by_id_async(job.id, abort=True)
+    assert await pg_job_manager.fetch_job(queues=None) is None
+
+
 async def test_fetch_job_spacial_case_none_lock(
     pg_job_manager, deferred_job_factory, fetched_job_factory
 ):

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -145,8 +145,8 @@ def test_list_queues(shell, connector, capsys):
     shell.do_list_queues("")
     captured = capsys.readouterr()
     assert captured.out.splitlines() == [
-        "queue1: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
-        "queue2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
+        "queue1: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
+        "queue2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
     ]
     assert connector.queries == [
         (
@@ -163,7 +163,7 @@ def test_list_queues_filters(shell, connector, capsys):
     shell.do_list_queues("queue=queue2 task=task2 lock=lock2 status=todo")
     captured = capsys.readouterr()
     assert captured.out.splitlines() == [
-        "queue2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
+        "queue2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
     ]
     assert connector.queries == [
         (
@@ -191,8 +191,8 @@ def test_list_tasks(shell, connector, capsys):
     shell.do_list_tasks("")
     captured = capsys.readouterr()
     assert captured.out.splitlines() == [
-        "task1: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
-        "task2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
+        "task1: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
+        "task2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
     ]
     assert connector.queries == [
         (
@@ -209,7 +209,7 @@ def test_list_tasks_filters(shell, connector, capsys):
     shell.do_list_tasks("queue=queue2 task=task2 lock=lock2 status=todo")
     captured = capsys.readouterr()
     assert captured.out.splitlines() == [
-        "task2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
+        "task2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
     ]
     assert connector.queries == [
         (
@@ -237,8 +237,8 @@ def test_list_locks(shell, connector, capsys):
     shell.do_list_locks("")
     captured = capsys.readouterr()
     assert captured.out.splitlines() == [
-        "lock1: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
-        "lock2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
+        "lock1: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
+        "lock2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
     ]
     assert connector.queries == [
         (
@@ -255,7 +255,7 @@ def test_list_locks_filters(shell, connector, capsys):
     shell.do_list_locks("queue=queue2 task=task2 lock=lock2 status=todo")
     captured = capsys.readouterr()
     assert captured.out.splitlines() == [
-        "lock2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0)",
+        "lock2: 1 jobs (todo: 1, doing: 0, succeeded: 0, failed: 0, cancelled: 0, aborting: 0, aborted: 0)",
     ]
     assert connector.queries == [
         (
@@ -314,4 +314,4 @@ def test_cancel(shell, connector, capsys):
 
     shell.do_cancel("1")
     captured = capsys.readouterr()
-    assert captured.out.strip() == "#1 task on queue - [failed]"
+    assert captured.out.strip() == "#1 task on queue - [cancelled]"


### PR DESCRIPTION
Closes #511 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [x] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

The only thing it breaks is when using the `shell` that `cancel` will leave the `job` in `cancelled` status (before the change it was left with `failed`). But I see it more as a fix than a breaking change.

The design decisions should be clear from the documentation page.

There are maybe parts to improve (maybe the acceptance tests?). Providing and testing sync and async APIs is quite hard, and sometimes also quite ugly 🙄. And in the end, it was more additional code than I thought.