### PR TITLE
fix: add default args to cli shell command to avoid missing args error

### DIFF
--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -644,7 +644,7 @@ async def healthchecks(app: procrastinate.App):
     print("Found procrastinate_jobs table: OK")
 
 
-async def shell_(app: procrastinate.App, args: list[str]):
+async def shell_(app: procrastinate.App, args: list[str] = []):
     """
     Administration shell for procrastinate.
     """

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -644,7 +644,7 @@ async def healthchecks(app: procrastinate.App):
     print("Found procrastinate_jobs table: OK")
 
 
-async def shell_(app: procrastinate.App, args: list[str] = []):
+async def shell_(app: procrastinate.App, args: list[str] | None = None):
     """
     Administration shell for procrastinate.
     """


### PR DESCRIPTION
Closes #<ticket number>

Hi! How is it going?

First, thank you so much for this project; it is amazing!

The problem that this PR proposes to resolve occurs when we try to use `./manage.py procrastinate shell` in django. The command raises the following error:

```
2024-07-03 13:42:31,117 DEBUG   procrastinate.cli Exception details:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/procrastinate/cli.py", line 522, in execute_command
    await parsed.pop("func")(app=app, **parsed)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: shell_() missing 1 required positional argument: 'args'
shell_() missing 1 required positional argument: 'args'
```

With that simple change, everthing works normally.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [X] (not applicable?)
- [ ] Documentation
  - [X] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [X] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
