### PR TITLE
Allow to change the priority of a to be retried job

### DIFF
--- a/docs/howto/advanced/retry.md
+++ b/docs/howto/advanced/retry.md
@@ -88,7 +88,7 @@ between retries:
           )
   ```
 
-- There is is also a legacy `get_schedule_in` method that is depreciated an will be
+- There is also a legacy `get_schedule_in` method that is deprecated an will be
   removed in a future version in favor of the above `get_retry_decision` method.
 
   ```python

--- a/docs/howto/advanced/retry.md
+++ b/docs/howto/advanced/retry.md
@@ -63,12 +63,15 @@ between retries:
 
 ## Implementing your own strategy
 
-- If you want to go for a fully fledged custom retry strategy, you can implement your
-  own retry strategy by returning a `RetryDecision` object from the
-  `get_retry_decision` method. This also allows to (optionally) change the priority,
-  the queue or the lock of the job. The time to wait between retries can be specified
-  with `retry_in` or alternatively with `retry_at`. If `None` is returned
-  from `get_retry_decision` then the job will not be retried.
+If you want to go for a fully fledged custom retry strategy, you can implement your
+own retry strategy by returning a `RetryDecision` object from the
+`get_retry_decision` method. This also allows to (optionally) change the priority,
+the queue or the lock of the job. If `None` is returned from `get_retry_decision`
+then the job will not be retried.
+
+The time to wait between retries can be specified with `retry_in` or alternatively
+with `retry_at`. This is similar to how `schedule_in` and `schedule_at` are used
+when {doc}`scheduling a job in the future <schedule>`.
 
   ```python
   import random
@@ -86,27 +89,12 @@ between retries:
           wait = random.uniform(self.min, self.max)
 
           return RetryDecision(
-              retry_in={"seconds": 10}, # or retry_at (a datetime object)
+              retry_in={"seconds": wait}, # or retry_at (a datetime object)
               priority=job.priority + 1, # optional
               queue="another_queue", # optional
               lock="another_lock", # optional
           )
   ```
 
-- There is also a legacy `get_schedule_in` method that is deprecated an will be
-  removed in a future version in favor of the above `get_retry_decision` method.
-
-  ```python
-  import random
-
-  class RandomRetryStrategy(procrastinate.BaseRetryStrategy):
-      max_attempts = 3
-      min = 1
-      max = 10
-
-      def get_schedule_in(self, *, exception:Exception, attempts: int) -> int:
-          if attempts >= max_attempts:
-              return None
-
-          return random.uniform(self.min, self.max)
-  ```
+There is also a legacy `get_schedule_in` method that is deprecated an will be
+removed in a future version in favor of the above `get_retry_decision` method.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -72,7 +72,12 @@ Retry strategies
 .. autoclass:: procrastinate.RetryStrategy
 
 .. autoclass:: procrastinate.BaseRetryStrategy
-    :members: get_schedule_in
+    :members: get_retry_decision, get_schedule_in
+
+.. deprecated:: 2.9
+    The `get_schedule_in` method is deprecated.
+
+.. autoclass:: procrastinate.RetryDecision
 
 
 Exceptions

--- a/procrastinate/__init__.py
+++ b/procrastinate/__init__.py
@@ -6,7 +6,7 @@ from procrastinate.blueprints import Blueprint
 from procrastinate.connector import BaseConnector
 from procrastinate.job_context import JobContext
 from procrastinate.psycopg_connector import PsycopgConnector
-from procrastinate.retry import BaseRetryStrategy, RetryStrategy
+from procrastinate.retry import BaseRetryStrategy, RetryDecision, RetryStrategy
 from procrastinate.sync_psycopg_connector import SyncPsycopgConnector
 from procrastinate.utils import MovedElsewhere as _MovedElsewhere
 
@@ -27,6 +27,7 @@ __all__ = [
     "BaseRetryStrategy",
     "PsycopgConnector",
     "SyncPsycopgConnector",
+    "RetryDecision",
     "RetryStrategy",
 ]
 

--- a/procrastinate/contrib/django/migrations/0029_add_additional_params_to_retry_job.py
+++ b/procrastinate/contrib/django/migrations/0029_add_additional_params_to_retry_job.py
@@ -8,8 +8,8 @@ from .. import migrations_utils
 class Migration(migrations.Migration):
     operations = [
         migrations_utils.RunProcrastinateSQL(
-            name="02.08.00_01_add_new_priority_to_retry_job.sql"
+            name="02.08.00_01_add_additional_params_to_retry_job.sql"
         ),
     ]
-    name = "0029_add_new_priority_to_retry_job"
+    name = "0029_add_additional_params_to_retry_job"
     dependencies = [("procrastinate", "0028_add_cancel_states")]

--- a/procrastinate/contrib/django/migrations/0029_add_new_priority_to_retry_job.py
+++ b/procrastinate/contrib/django/migrations/0029_add_new_priority_to_retry_job.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+from .. import migrations_utils
+
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations_utils.RunProcrastinateSQL(
+            name="02.08.00_01_add_new_priority_to_retry_job.sql"
+        ),
+    ]
+    name = "0029_add_new_priority_to_retry_job"
+    dependencies = [("procrastinate", "0028_add_cancel_states")]

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import datetime
+from procrastinate.retry import RetryDecision
 
 
 class ProcrastinateException(Exception):
@@ -45,11 +45,8 @@ class JobRetry(ProcrastinateException):
     Job should be retried.
     """
 
-    def __init__(
-        self, scheduled_at: datetime.datetime, new_priority: int | None = None
-    ):
-        self.scheduled_at = scheduled_at
-        self.new_priority = new_priority
+    def __init__(self, retry_decision: RetryDecision):
+        self.retry_decision = retry_decision
         super().__init__()
 
 

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -45,8 +45,11 @@ class JobRetry(ProcrastinateException):
     Job should be retried.
     """
 
-    def __init__(self, scheduled_at: datetime.datetime):
+    def __init__(
+        self, scheduled_at: datetime.datetime, new_priority: int | None = None
+    ):
         self.scheduled_at = scheduled_at
+        self.new_priority = new_priority
         super().__init__()
 
 

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -357,7 +357,9 @@ class JobManager:
         self,
         job: jobs.Job,
         retry_at: datetime.datetime | None = None,
-        new_priority: int | None = None,
+        priority: int | None = None,
+        queue: str | None = None,
+        lock: str | None = None,
     ) -> None:
         """
         Indicates that a job should be retried later.
@@ -369,22 +371,32 @@ class JobManager:
             If set at present time or in the past, the job may be retried immediately.
             Otherwise, the job will be retried no sooner than this date & time.
             Should be timezone-aware (even if UTC). Defaults to present time.
-        new_priority : ``Optional[int]``
-            If set, the job will be retried with this priority. If not set, the job will
-            use its original priority.
+        priority : ``Optional[int]``
+            If set, the job will be retried with this priority. If not set, the priority
+            remains unchanged.
+        queue : ``Optional[int]``
+            If set, the job will be retried on this queue. If not set, the queue remains
+            unchanged.
+        lock : ``Optional[int]``
+            If set, the job will be retried with this lock. If not set, the lock remains
+            unchanged.
         """
         assert job.id  # TODO remove this
         await self.retry_job_by_id_async(
             job_id=job.id,
             retry_at=retry_at or utils.utcnow(),
-            new_priority=new_priority,
+            priority=priority,
+            queue=queue,
+            lock=lock,
         )
 
     async def retry_job_by_id_async(
         self,
         job_id: int,
         retry_at: datetime.datetime,
-        new_priority: int | None = None,
+        priority: int | None = None,
+        queue: str | None = None,
+        lock: str | None = None,
     ) -> None:
         """
         Indicates that a job should be retried later.
@@ -396,22 +408,32 @@ class JobManager:
             If set at present time or in the past, the job may be retried immediately.
             Otherwise, the job will be retried no sooner than this date & time.
             Should be timezone-aware (even if UTC).
-        new_priority : ``Optional[int]``
-            If set, the job will be retried with this priority. If not set, the job will
-            use its original priority.
+        priority : ``Optional[int]``
+            If set, the job will be retried with this priority. If not set, the priority
+            remains unchanged.
+        queue : ``Optional[int]``
+            If set, the job will be retried on this queue. If not set, the queue remains
+            unchanged.
+        lock : ``Optional[int]``
+            If set, the job will be retried with this lock. If not set, the lock remains
+            unchanged.
         """
         await self.connector.execute_query_async(
             query=sql.queries["retry_job"],
             job_id=job_id,
             retry_at=retry_at,
-            new_priority=new_priority,
+            new_priority=priority,
+            new_queue_name=queue,
+            new_lock=lock,
         )
 
     def retry_job_by_id(
         self,
         job_id: int,
         retry_at: datetime.datetime,
-        new_priority: int | None = None,
+        priority: int | None = None,
+        queue: str | None = None,
+        lock: str | None = None,
     ) -> None:
         """
         Sync version of `retry_job_by_id_async`.
@@ -420,7 +442,9 @@ class JobManager:
             query=sql.queries["retry_job"],
             job_id=job_id,
             retry_at=retry_at,
-            new_priority=new_priority,
+            new_priority=priority,
+            new_queue_name=queue,
+            new_lock=lock,
         )
 
     async def listen_for_jobs(

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -357,6 +357,7 @@ class JobManager:
         self,
         job: jobs.Job,
         retry_at: datetime.datetime | None = None,
+        new_priority: int | None = None,
     ) -> None:
         """
         Indicates that a job should be retried later.
@@ -368,16 +369,22 @@ class JobManager:
             If set at present time or in the past, the job may be retried immediately.
             Otherwise, the job will be retried no sooner than this date & time.
             Should be timezone-aware (even if UTC). Defaults to present time.
+        new_priority : ``Optional[int]``
+            If set, the job will be retried with this priority. If not set, the job will
+            use its original priority.
         """
         assert job.id  # TODO remove this
         await self.retry_job_by_id_async(
-            job_id=job.id, retry_at=retry_at or utils.utcnow()
+            job_id=job.id,
+            retry_at=retry_at or utils.utcnow(),
+            new_priority=new_priority,
         )
 
     async def retry_job_by_id_async(
         self,
         job_id: int,
         retry_at: datetime.datetime,
+        new_priority: int | None = None,
     ) -> None:
         """
         Indicates that a job should be retried later.
@@ -389,17 +396,22 @@ class JobManager:
             If set at present time or in the past, the job may be retried immediately.
             Otherwise, the job will be retried no sooner than this date & time.
             Should be timezone-aware (even if UTC).
+        new_priority : ``Optional[int]``
+            If set, the job will be retried with this priority. If not set, the job will
+            use its original priority.
         """
         await self.connector.execute_query_async(
             query=sql.queries["retry_job"],
             job_id=job_id,
             retry_at=retry_at,
+            new_priority=new_priority,
         )
 
     def retry_job_by_id(
         self,
         job_id: int,
         retry_at: datetime.datetime,
+        new_priority: int | None = None,
     ) -> None:
         """
         Sync version of `retry_job_by_id_async`.
@@ -408,6 +420,7 @@ class JobManager:
             query=sql.queries["retry_job"],
             job_id=job_id,
             retry_at=retry_at,
+            new_priority=new_priority,
         )
 
     async def listen_for_jobs(

--- a/procrastinate/retry.py
+++ b/procrastinate/retry.py
@@ -48,6 +48,28 @@ class RetryDecision:
         queue: str | None = None,
         lock: str | None = None,
     ) -> None:
+        """
+        Specifies when and how a job should be retried.
+
+        Parameters
+        ----------
+        retry_at : ``Optional[datetime.datetime]``
+            If set at present time or in the past, the job may be retried immediately.
+            Otherwise, the job will be retried no sooner than this date & time.
+            Should be timezone-aware (even if UTC). Defaults to present time.
+        retry_in : ``Optional[types.TimeDeltaParams]``
+            If set, the job will be retried after this duration. If not set, the job will
+            be retried immediately.
+        priority : ``Optional[int]``
+            If set, the job will be retried with this priority. If not set, the priority
+            remains unchanged.
+        queue : ``Optional[int]``
+            If set, the job will be retried on this queue. If not set, the queue remains
+            unchanged.
+        lock : ``Optional[int]``
+            If set, the job will be retried with this lock. If not set, the lock remains
+            unchanged.
+        """
         if retry_at and retry_in is not None:
             raise ValueError("Cannot set both retry_at and retry_in")
 
@@ -127,14 +149,6 @@ class BaseRetryStrategy:
             The exception raised by the job
         job:
             The current job
-
-        Returns
-        -------
-        ``RetryDecision``
-            A RetryDecision object with the following attributes:
-            - should_retry: a boolean indicating whether the job should be retried
-            - schedule_in: an optional float indicating the number of seconds to wait
-            - priority: an optional integer indicating the new priority of the job
         """
         raise NotImplementedError("Missing implementation of 'get_retry_decision'.")
 

--- a/procrastinate/retry.py
+++ b/procrastinate/retry.py
@@ -11,7 +11,7 @@ from typing import Iterable, Union, overload
 
 import attr
 
-from procrastinate import exceptions, utils
+from procrastinate import exceptions, types, utils
 from procrastinate.jobs import Job
 
 
@@ -25,7 +25,7 @@ class RetryDecision:
     def __init__(
         self,
         retry_at: None = None,
-        retry_in: utils.TimeDeltaParams | None = None,
+        retry_in: types.TimeDeltaParams | None = None,
         priority: int | None = None,
         queue: str | None = None,
         lock: str | None = None,
@@ -42,7 +42,7 @@ class RetryDecision:
     def __init__(
         self,
         retry_at: datetime.datetime | None = None,
-        retry_in: utils.TimeDeltaParams | None = None,
+        retry_in: types.TimeDeltaParams | None = None,
         priority: int | None = None,
         queue: str | None = None,
         lock: str | None = None,

--- a/procrastinate/retry.py
+++ b/procrastinate/retry.py
@@ -24,8 +24,8 @@ class RetryDecision:
     @overload
     def __init__(
         self,
-        retry_at: None = None,
-        retry_in: types.TimeDeltaParams | None = None,
+        *,
+        retry_at: datetime.datetime | None = None,
         priority: int | None = None,
         queue: str | None = None,
         lock: str | None = None,
@@ -33,14 +33,15 @@ class RetryDecision:
     @overload
     def __init__(
         self,
-        retry_at: datetime.datetime | None = None,
-        retry_in: None = None,
+        *,
+        retry_in: types.TimeDeltaParams | None = None,
         priority: int | None = None,
         queue: str | None = None,
         lock: str | None = None,
     ) -> None: ...
     def __init__(
         self,
+        *,
         retry_at: datetime.datetime | None = None,
         retry_in: types.TimeDeltaParams | None = None,
         priority: int | None = None,

--- a/procrastinate/retry.py
+++ b/procrastinate/retry.py
@@ -80,7 +80,7 @@ class BaseRetryStrategy:
                     exception=exception, attempts=job.attempts
                 )
             except NotImplementedError:
-                raise err
+                raise err from None
 
             warnings.warn(
                 "`get_schedule_in` is deprecated, use `get_retry_decision` instead.",

--- a/procrastinate/retry.py
+++ b/procrastinate/retry.py
@@ -74,15 +74,20 @@ class BaseRetryStrategy:
                 return None
 
             return exceptions.JobRetry(retry_decision=retry_decision)
-        except NotImplementedError:
+        except NotImplementedError as err:
+            try:
+                schedule_in = self.get_schedule_in(
+                    exception=exception, attempts=job.attempts
+                )
+            except NotImplementedError:
+                raise err
+
             warnings.warn(
                 "`get_schedule_in` is deprecated, use `get_retry_decision` instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            schedule_in = self.get_schedule_in(
-                exception=exception, attempts=job.attempts
-            )
+
             if schedule_in is None:
                 return None
 
@@ -109,7 +114,7 @@ class BaseRetryStrategy:
         This function is deprecated and will be removed in a future version. Use
         `get_retry_decision` instead.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def get_retry_decision(
         self, *, exception: BaseException, job: Job
@@ -130,7 +135,7 @@ class BaseRetryStrategy:
             - schedule_in: an optional float indicating the number of seconds to wait
             - priority: an optional integer indicating the new priority of the job
         """
-        raise NotImplementedError()
+        raise NotImplementedError("Missing implementation of 'get_retry_decision'.")
 
 
 @attr.dataclass(kw_only=True)

--- a/procrastinate/sql/migrations/02.08.00_01_add_additional_params_to_retry_job.sql
+++ b/procrastinate/sql/migrations/02.08.00_01_add_additional_params_to_retry_job.sql
@@ -1,4 +1,10 @@
-CREATE OR REPLACE FUNCTION procrastinate_retry_job(job_id bigint, retry_at timestamp with time zone, new_priority integer)
+CREATE OR REPLACE FUNCTION procrastinate_retry_job(
+    job_id bigint,
+    retry_at timestamp with time zone,
+    new_priority integer,
+    new_queue_name character varying,
+    new_lock character varying
+)
     RETURNS void
     LANGUAGE plpgsql
 AS $$
@@ -9,7 +15,9 @@ BEGIN
     SET status = 'todo',
         attempts = attempts + 1,
         scheduled_at = retry_at,
-        priority = COALESCE(new_priority, priority)
+        priority = COALESCE(new_priority, priority),
+        queue_name = COALESCE(new_queue_name, queue_name),
+        lock = COALESCE(new_lock, lock)
     WHERE id = job_id AND status = 'doing'
     RETURNING id INTO _job_id;
     IF _job_id IS NULL THEN

--- a/procrastinate/sql/migrations/02.08.00_01_add_new_priority_to_retry_job.sql
+++ b/procrastinate/sql/migrations/02.08.00_01_add_new_priority_to_retry_job.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION procrastinate_retry_job(job_id bigint, retry_at timestamp with time zone, new_priority integer)
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    _job_id bigint;
+BEGIN
+    UPDATE procrastinate_jobs
+    SET status = 'todo',
+        attempts = attempts + 1,
+        scheduled_at = retry_at,
+        priority = COALESCE(new_priority, priority)
+    WHERE id = job_id AND status = 'doing'
+    RETURNING id INTO _job_id;
+    IF _job_id IS NULL THEN
+        RAISE 'Job was not found or not in "doing" status (job id: %)', job_id;
+    END IF;
+END;
+$$;

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -60,7 +60,7 @@ SELECT status FROM procrastinate_jobs WHERE id = %(job_id)s;
 
 -- retry_job --
 -- Retry a job, changing it from "doing" to "todo"
-SELECT procrastinate_retry_job(%(job_id)s, %(retry_at)s);
+SELECT procrastinate_retry_job(%(job_id)s, %(retry_at)s, %(new_priority)s);
 
 -- listen_queue --
 -- In this one, the argument is an identifier, shoud not be escaped the same way

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -60,7 +60,7 @@ SELECT status FROM procrastinate_jobs WHERE id = %(job_id)s;
 
 -- retry_job --
 -- Retry a job, changing it from "doing" to "todo"
-SELECT procrastinate_retry_job(%(job_id)s, %(retry_at)s, %(new_priority)s);
+SELECT procrastinate_retry_job(%(job_id)s, %(retry_at)s, %(new_priority)s, %(new_queue_name)s, %(new_lock)s);
 
 -- listen_queue --
 -- In this one, the argument is an identifier, shoud not be escaped the same way

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -259,7 +259,13 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION procrastinate_retry_job(job_id bigint, retry_at timestamp with time zone, new_priority integer)
+CREATE FUNCTION procrastinate_retry_job(
+    job_id bigint,
+    retry_at timestamp with time zone,
+    new_priority integer,
+    new_queue_name character varying,
+    new_lock character varying
+)
     RETURNS void
     LANGUAGE plpgsql
 AS $$
@@ -270,7 +276,9 @@ BEGIN
     SET status = 'todo',
         attempts = attempts + 1,
         scheduled_at = retry_at,
-        priority = COALESCE(new_priority, priority)
+        priority = COALESCE(new_priority, priority),
+        queue_name = COALESCE(new_queue_name, queue_name),
+        lock = COALESCE(new_lock, lock)
     WHERE id = job_id AND status = 'doing'
     RETURNING id INTO _job_id;
     IF _job_id IS NULL THEN
@@ -517,7 +525,7 @@ END;
 $$;
 
 -- procrastinate_retry_job
--- the function without the new_priority argument is kept for compatibility reasons
+-- the function without the new_* arguments is kept for compatibility reasons
 CREATE FUNCTION procrastinate_retry_job(job_id bigint, retry_at timestamp with time zone)
     RETURNS void
     LANGUAGE plpgsql

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -239,6 +239,4 @@ class Task(Generic[P, Args]):
         if not self.retry_strategy:
             return None
 
-        return self.retry_strategy.get_retry_exception(
-            exception=exception, attempts=job.attempts
-        )
+        return self.retry_strategy.get_retry_exception(exception=exception, job=job)

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -22,7 +22,7 @@ class ConfigureTaskOptions(TypedDict):
     queueing_lock: NotRequired[str | None]
     task_kwargs: NotRequired[types.JSONDict | None]
     schedule_at: NotRequired[datetime.datetime | None]
-    schedule_in: NotRequired[utils.TimeDeltaParams | None]
+    schedule_in: NotRequired[types.TimeDeltaParams | None]
     queue: NotRequired[str | None]
     priority: NotRequired[int | None]
 

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -17,22 +17,12 @@ Args = ParamSpec("Args")
 P = ParamSpec("P")
 
 
-class TimeDeltaParams(TypedDict):
-    weeks: NotRequired[int]
-    days: NotRequired[int]
-    hours: NotRequired[int]
-    minutes: NotRequired[int]
-    seconds: NotRequired[int]
-    milliseconds: NotRequired[int]
-    microseconds: NotRequired[int]
-
-
 class ConfigureTaskOptions(TypedDict):
     lock: NotRequired[str | None]
     queueing_lock: NotRequired[str | None]
     task_kwargs: NotRequired[types.JSONDict | None]
     schedule_at: NotRequired[datetime.datetime | None]
-    schedule_in: NotRequired[TimeDeltaParams | None]
+    schedule_in: NotRequired[utils.TimeDeltaParams | None]
     queue: NotRequired[str | None]
     priority: NotRequired[int | None]
 
@@ -51,7 +41,7 @@ def configure_task(
         raise ValueError("Cannot set both schedule_at and schedule_in")
 
     if schedule_in is not None:
-        schedule_at = utils.utcnow() + datetime.timedelta(**schedule_in)
+        schedule_at = utils.datetime_from_timedelta_params(schedule_in)
 
     if priority is None:
         priority = jobs.DEFAULT_PRIORITY

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -245,7 +245,12 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         return {"status": self.jobs[job_id]["status"]}
 
     def retry_job_run(
-        self, job_id: int, retry_at: datetime.datetime, new_priority: int | None = None
+        self,
+        job_id: int,
+        retry_at: datetime.datetime,
+        new_priority: int | None = None,
+        new_queue_name: str | None = None,
+        new_lock: str | None = None,
     ) -> None:
         job_row = self.jobs[job_id]
         job_row["status"] = "todo"
@@ -253,6 +258,10 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         job_row["scheduled_at"] = retry_at
         if new_priority is not None:
             job_row["priority"] = new_priority
+        if new_queue_name is not None:
+            job_row["queue_name"] = new_queue_name
+        if new_lock is not None:
+            job_row["lock"] = new_lock
         self.events[job_id].append({"type": "scheduled", "at": retry_at})
         self.events[job_id].append({"type": "deferred_for_retry", "at": utils.utcnow()})
 

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -244,11 +244,15 @@ class InMemoryConnector(connector.BaseAsyncConnector):
     def get_job_status_one(self, job_id: int) -> dict:
         return {"status": self.jobs[job_id]["status"]}
 
-    def retry_job_run(self, job_id: int, retry_at: datetime.datetime) -> None:
+    def retry_job_run(
+        self, job_id: int, retry_at: datetime.datetime, new_priority: int | None = None
+    ) -> None:
         job_row = self.jobs[job_id]
         job_row["status"] = "todo"
         job_row["attempts"] += 1
         job_row["scheduled_at"] = retry_at
+        if new_priority is not None:
+            job_row["priority"] = new_priority
         self.events[job_id].append({"type": "scheduled", "at": retry_at})
         self.events[job_id].append({"type": "deferred_for_retry", "at": utils.utcnow()})
 

--- a/procrastinate/types.py
+++ b/procrastinate/types.py
@@ -2,5 +2,17 @@ from __future__ import annotations
 
 import typing as t
 
+from typing_extensions import NotRequired
+
 JSONValue = t.Union[str, int, float, bool, None, t.Dict[str, t.Any], t.List[t.Any]]
 JSONDict = t.Dict[str, JSONValue]
+
+
+class TimeDeltaParams(t.TypedDict):
+    weeks: NotRequired[int]
+    days: NotRequired[int]
+    hours: NotRequired[int]
+    minutes: NotRequired[int]
+    seconds: NotRequired[int]
+    milliseconds: NotRequired[int]
+    microseconds: NotRequired[int]

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -18,16 +18,15 @@ from typing import (
     Coroutine,
     Generic,
     Iterable,
-    TypedDict,
     TypeVar,
 )
 
 import attr
 import dateutil.parser
 from asgiref import sync
-from typing_extensions import NotRequired
 
 from procrastinate import exceptions
+from procrastinate.types import TimeDeltaParams
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -434,16 +433,6 @@ def async_context_decorator(func: Callable) -> Callable:
         return contextlib2.asynccontextmanager(func)
     else:
         return contextlib.asynccontextmanager(func)
-
-
-class TimeDeltaParams(TypedDict):
-    weeks: NotRequired[int]
-    days: NotRequired[int]
-    hours: NotRequired[int]
-    minutes: NotRequired[int]
-    seconds: NotRequired[int]
-    milliseconds: NotRequired[int]
-    microseconds: NotRequired[int]
 
 
 def datetime_from_timedelta_params(params: TimeDeltaParams) -> datetime.datetime:

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -18,12 +18,14 @@ from typing import (
     Coroutine,
     Generic,
     Iterable,
+    TypedDict,
     TypeVar,
 )
 
 import attr
 import dateutil.parser
 from asgiref import sync
+from typing_extensions import NotRequired
 
 from procrastinate import exceptions
 
@@ -432,3 +434,17 @@ def async_context_decorator(func: Callable) -> Callable:
         return contextlib2.asynccontextmanager(func)
     else:
         return contextlib.asynccontextmanager(func)
+
+
+class TimeDeltaParams(TypedDict):
+    weeks: NotRequired[int]
+    days: NotRequired[int]
+    hours: NotRequired[int]
+    minutes: NotRequired[int]
+    seconds: NotRequired[int]
+    milliseconds: NotRequired[int]
+    microseconds: NotRequired[int]
+
+
+def datetime_from_timedelta_params(params: TimeDeltaParams) -> datetime.datetime:
+    return utcnow() + datetime.timedelta(**params)

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -191,7 +191,7 @@ class Worker:
             extra=context.log_extra(action="loaded_job_info"),
         )
 
-        status, retry_at, new_priority = None, None, None
+        status, retry_decision = None, None
         try:
             await self.run_job(job=job, worker_id=worker_id)
             status = jobs.Status.SUCCEEDED
@@ -201,8 +201,7 @@ class Worker:
         except exceptions.JobError as e:
             status = jobs.Status.FAILED
             if e.retry_exception:
-                retry_at = e.retry_exception.scheduled_at
-                new_priority = e.retry_exception.new_priority
+                retry_decision = e.retry_exception.retry_decision
             if e.critical and e.__cause__:
                 raise e.__cause__
 
@@ -213,9 +212,13 @@ class Worker:
                 extra=context.log_extra(action="task_not_found", exception=str(exc)),
             )
         finally:
-            if retry_at:
+            if retry_decision:
                 await self.job_manager.retry_job(
-                    job=job, retry_at=retry_at, new_priority=new_priority
+                    job=job,
+                    retry_at=retry_decision.retry_at,
+                    priority=retry_decision.priority,
+                    queue=retry_decision.queue,
+                    lock=retry_decision.lock,
                 )
             else:
                 assert status is not None

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -305,11 +305,15 @@ async def test_retry_job(pg_job_manager, fetched_job_factory):
     assert job2.priority == job1.priority == 0
 
 
-async def test_retry_job_with_new_priority(pg_job_manager, fetched_job_factory):
+async def test_retry_job_with_additional_params(pg_job_manager, fetched_job_factory):
     job1 = await fetched_job_factory(queue="queue_a")
 
     await pg_job_manager.retry_job(
-        job=job1, retry_at=datetime.datetime.now(datetime.timezone.utc), new_priority=5
+        job=job1,
+        retry_at=datetime.datetime.now(datetime.timezone.utc),
+        priority=5,
+        queue="queue_b",
+        lock="some_lock",
     )
 
     job2 = await pg_job_manager.fetch_job(queues=None)
@@ -317,6 +321,8 @@ async def test_retry_job_with_new_priority(pg_job_manager, fetched_job_factory):
     assert job2.id == job1.id
     assert job2.attempts == job1.attempts + 1
     assert job2.priority == 5
+    assert job2.queue == "queue_b"
+    assert job2.lock == "some_lock"
 
 
 async def test_enum_synced(psycopg_connector):

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -302,6 +302,21 @@ async def test_retry_job(pg_job_manager, fetched_job_factory):
 
     assert job2.id == job1.id
     assert job2.attempts == job1.attempts + 1
+    assert job2.priority == job1.priority == 0
+
+
+async def test_retry_job_with_new_priority(pg_job_manager, fetched_job_factory):
+    job1 = await fetched_job_factory(queue="queue_a")
+
+    await pg_job_manager.retry_job(
+        job=job1, retry_at=datetime.datetime.now(datetime.timezone.utc), new_priority=5
+    )
+
+    job2 = await pg_job_manager.fetch_job(queues=None)
+
+    assert job2.id == job1.id
+    assert job2.attempts == job1.attempts + 1
+    assert job2.priority == 5
 
 
 async def test_enum_synced(psycopg_connector):

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -319,7 +319,7 @@ async def test_retry_job_with_additional_params(pg_job_manager, fetched_job_fact
     job2 = await pg_job_manager.fetch_job(queues=None)
 
     assert job2.id == job1.id
-    assert job2.attempts == job1.attempts + 1
+    assert job2.attempts == 1
     assert job2.priority == 5
     assert job2.queue == "queue_b"
     assert job2.lock == "some_lock"

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -275,10 +275,18 @@ async def test_retry_job(job_manager, job_factory, connector):
     await job_manager.defer_job_async(job=job)
     retry_at = conftest.aware_datetime(2000, 1, 1)
 
-    await job_manager.retry_job(job=job, retry_at=retry_at, new_priority=7)
+    await job_manager.retry_job(
+        job=job, retry_at=retry_at, priority=7, queue="some_queue", lock="some_lock"
+    )
     assert connector.queries[-1] == (
         "retry_job",
-        {"job_id": 1, "retry_at": retry_at, "new_priority": 7},
+        {
+            "job_id": 1,
+            "retry_at": retry_at,
+            "new_priority": 7,
+            "new_queue_name": "some_queue",
+            "new_lock": "some_lock",
+        },
     )
 
 
@@ -399,22 +407,38 @@ def dt():
 async def test_retry_job_by_id_async(job_manager, connector, job_factory, dt):
     job = await job_manager.defer_job_async(job=job_factory())
 
-    await job_manager.retry_job_by_id_async(job_id=job.id, retry_at=dt, new_priority=7)
+    await job_manager.retry_job_by_id_async(
+        job_id=job.id, retry_at=dt, priority=7, queue="some_queue", lock="some_lock"
+    )
 
     assert connector.queries[-1] == (
         "retry_job",
-        {"job_id": 1, "retry_at": dt, "new_priority": 7},
+        {
+            "job_id": 1,
+            "retry_at": dt,
+            "new_priority": 7,
+            "new_queue_name": "some_queue",
+            "new_lock": "some_lock",
+        },
     )
 
 
 def test_retry_job_by_id(job_manager, connector, job_factory, dt):
     job = job_manager.defer_job(job=job_factory())
 
-    job_manager.retry_job_by_id(job_id=job.id, retry_at=dt, new_priority=7)
+    job_manager.retry_job_by_id(
+        job_id=job.id, retry_at=dt, priority=7, queue="some_queue", lock="some_lock"
+    )
 
     assert connector.queries[-1] == (
         "retry_job",
-        {"job_id": 1, "retry_at": dt, "new_priority": 7},
+        {
+            "job_id": 1,
+            "retry_at": dt,
+            "new_priority": 7,
+            "new_queue_name": "some_queue",
+            "new_lock": "some_lock",
+        },
     )
 
 

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -275,10 +275,10 @@ async def test_retry_job(job_manager, job_factory, connector):
     await job_manager.defer_job_async(job=job)
     retry_at = conftest.aware_datetime(2000, 1, 1)
 
-    await job_manager.retry_job(job=job, retry_at=retry_at)
+    await job_manager.retry_job(job=job, retry_at=retry_at, new_priority=7)
     assert connector.queries[-1] == (
         "retry_job",
-        {"job_id": 1, "retry_at": retry_at},
+        {"job_id": 1, "retry_at": retry_at, "new_priority": 7},
     )
 
 
@@ -399,22 +399,22 @@ def dt():
 async def test_retry_job_by_id_async(job_manager, connector, job_factory, dt):
     job = await job_manager.defer_job_async(job=job_factory())
 
-    await job_manager.retry_job_by_id_async(job_id=job.id, retry_at=dt)
+    await job_manager.retry_job_by_id_async(job_id=job.id, retry_at=dt, new_priority=7)
 
     assert connector.queries[-1] == (
         "retry_job",
-        {"job_id": 1, "retry_at": dt},
+        {"job_id": 1, "retry_at": dt, "new_priority": 7},
     )
 
 
 def test_retry_job_by_id(job_manager, connector, job_factory, dt):
     job = job_manager.defer_job(job=job_factory())
 
-    job_manager.retry_job_by_id(job_id=job.id, retry_at=dt)
+    job_manager.retry_job_by_id(job_id=job.id, retry_at=dt, new_priority=7)
 
     assert connector.queries[-1] == (
         "retry_job",
-        {"job_id": 1, "retry_at": dt},
+        {"job_id": 1, "retry_at": dt, "new_priority": 7},
     )
 
 

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -194,12 +194,12 @@ def test_custom_retry_strategy_depreciated_returns(mocker):
     assert exc.retry_decision.retry_at == expected.replace(microsecond=0)
 
 
-def test_missing_implementation_in_custom_retry_strategy(mocker):
+def test_missing_implementation_of_custom_retry_strategy(mocker):
     class CustomRetryStrategy(BaseRetryStrategy):
         pass
 
     strategy = CustomRetryStrategy()
     job_mock = mocker.Mock(attempts=1)
     with pytest.raises(NotImplementedError) as exc_info:
-        strategy.get_retry_decision(exception=Exception(), job=job_mock)
+        strategy.get_retry_exception(exception=Exception(), job=job_mock)
     assert str(exc_info.value) == "Missing implementation of 'get_retry_decision'."

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -63,6 +63,16 @@ def test_get_schedule_in_time(
     )
 
 
+def test_retry_decision_constructor():
+    now = conftest.aware_datetime(2000, 1, 1, tz_offset=1)
+    with pytest.raises(ValueError) as exc_info:
+        RetryDecision(
+            retry_in={"seconds": 42},
+            retry_at=now + datetime.timedelta(seconds=42, microseconds=0),
+        )
+    assert str(exc_info.value) == "Cannot set both retry_at and retry_in"
+
+
 @pytest.mark.parametrize(
     "attempts, wait, linear_wait, exponential_wait, retry_in",
     [

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -240,3 +240,14 @@ def test_custom_retry_strategy_depreciated_returns(mocker):
         exc = strategy.get_retry_exception(exception=Exception(), job=job_mock)
     assert isinstance(exc, exceptions.JobRetry)
     assert exc.retry_decision.retry_at == expected.replace(microsecond=0)
+
+
+def test_missing_implementation_in_custom_retry_strategy(mocker):
+    class CustomRetryStrategy(BaseRetryStrategy):
+        pass
+
+    strategy = CustomRetryStrategy()
+    job_mock = mocker.Mock(attempts=1)
+    with pytest.raises(NotImplementedError) as exc_info:
+        strategy.get_retry_decision(exception=Exception(), job=job_mock)
+    assert str(exc_info.value) == "Missing implementation of 'get_retry_decision'."

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -133,5 +133,5 @@ def test_task_get_retry_exception(app, mocker):
 
     exception = ValueError()
     assert task.get_retry_exception(exception=exception, job=job) is mock.return_value
-    mock.assert_called_with(exception=exception, attempts=0)
-    mock.assert_called_with(exception=exception, attempts=0)
+    mock.assert_called_with(exception=exception, job=job)
+    mock.assert_called_with(exception=exception, job=job)

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -383,11 +383,12 @@ def test_retry_job_run(connector):
     id = job_row["id"]
 
     retry_at = conftest.aware_datetime(2000, 1, 1)
-    connector.retry_job_run(job_id=id, retry_at=retry_at)
+    connector.retry_job_run(job_id=id, retry_at=retry_at, new_priority=3)
 
     assert connector.jobs[id]["attempts"] == 1
     assert connector.jobs[id]["status"] == "todo"
     assert connector.jobs[id]["scheduled_at"] == retry_at
+    assert connector.jobs[id]["priority"] == 3
     assert len(connector.events[id]) == 4
 
 

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -383,12 +383,20 @@ def test_retry_job_run(connector):
     id = job_row["id"]
 
     retry_at = conftest.aware_datetime(2000, 1, 1)
-    connector.retry_job_run(job_id=id, retry_at=retry_at, new_priority=3)
+    connector.retry_job_run(
+        job_id=id,
+        retry_at=retry_at,
+        new_priority=3,
+        new_queue_name="some_queue",
+        new_lock="some_lock",
+    )
 
     assert connector.jobs[id]["attempts"] == 1
     assert connector.jobs[id]["status"] == "todo"
     assert connector.jobs[id]["scheduled_at"] == retry_at
     assert connector.jobs[id]["priority"] == 3
+    assert connector.jobs[id]["queue_name"] == "some_queue"
+    assert connector.jobs[id]["lock"] == "some_lock"
     assert len(connector.events[id]) == 4
 
 


### PR DESCRIPTION
Closes #1096 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

As discussed in #1096 this PR allows to change the priority of a to be retried job by implementing a new API (`get_retry_decision` and `RetryDecision`). This PR is hopefully fully backward compatible, but I had to change the method signature of `BaseRetryStrategy.get_retry_exception` which I assume is internal API.