### PR TITLE
Can't use CLI parameters named args because of Django

### DIFF
--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -488,7 +488,7 @@ def configure_shell_parser(subparsers: argparse._SubParsersAction):
     )
     add_argument(
         shell_parser,
-        "args",
+        "shell_command",
         nargs="*",
         help="Invoke a shell command and exit",
     )
@@ -644,7 +644,7 @@ async def healthchecks(app: procrastinate.App):
     print("Found procrastinate_jobs table: OK")
 
 
-async def shell_(app: procrastinate.App, args: list[str]):
+async def shell_(app: procrastinate.App, shell_command: list[str]):
     """
     Administration shell for procrastinate.
     """
@@ -652,8 +652,8 @@ async def shell_(app: procrastinate.App, args: list[str]):
         job_manager=app.job_manager,
     )
 
-    if args:
-        await utils.sync_to_async(shell_obj.onecmd, line=shlex.join(args))
+    if shell_command:
+        await utils.sync_to_async(shell_obj.onecmd, line=shlex.join(shell_command))
     else:
         await utils.sync_to_async(shell_obj.cmdloop)
 

--- a/tests/unit/contrib/django/test_cli.py
+++ b/tests/unit/contrib/django/test_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+
+from procrastinate.contrib.django.management.commands import (
+    procrastinate as procrastinate_command,
+)
+
+
+def test_procrastinate_command():
+    # This test might be brittle as it uses internal argparse attributes
+    # It's linked to https://github.com/procrastinate-org/procrastinate/pull/1095
+    parser = procrastinate_command.Command().create_parser("manage.py", "procrastinate")
+
+    error = """
+    If this test fails, it means that an argument named "args" has been added
+    (or renamed) in the procrastinate CLI, and is exposed in the Django procrastinate
+    management command. This is problematic because "args" is a special name that
+    Django removes from the command line arguments before passing them to the
+    management command. To fix this error, use a different name for the argument.
+
+    See:
+        - https://github.com/django/django/blob/f9bf616597d56deac66d9d6bb753b028dd9634cc/django/core/management/base.py#L410
+        - https://github.com/procrastinate-org/procrastinate/pull/1095
+    """
+
+    def assert_no_action_named_args(parser):
+        for action in parser._actions:
+            assert getattr(action, "dest", "") != (
+                "args"
+            ), f"'args' found in {parser.prog}\n{error}"
+            if isinstance(action, argparse._SubParsersAction):
+                for subparser in action.choices.values():
+                    assert_no_action_named_args(subparser)
+
+    assert_no_action_named_args(parser)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -112,14 +112,14 @@ def test_main(mocker):
             ["shell"],
             {
                 "command": "shell",
-                "args": [],
+                "shell_command": [],
             },
         ),
         (
             ["shell", "list_jobs"],
             {
                 "command": "shell",
-                "args": ["list_jobs"],
+                "shell_command": ["list_jobs"],
             },
         ),
     ],
@@ -288,7 +288,7 @@ async def test_shell_single_command(app, capsys):
 
     await mytask.defer_async(a=1)
 
-    await cli.shell_(app=app, args=["list_jobs"])
+    await cli.shell_(app=app, shell_command=["list_jobs"])
 
     out, _ = capsys.readouterr()
 
@@ -304,7 +304,7 @@ async def test_shell_interactive_command(app, capsys, mocker):
 
     mocker.patch("sys.stdin", io.StringIO("list_jobs\nexit\n"))
 
-    await cli.shell_(app=app, args=[])
+    await cli.shell_(app=app, shell_command=[])
 
     out, _ = capsys.readouterr()
 


### PR DESCRIPTION
Closes #1095

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
