### PR TITLE
Allow to cache job status when checking abortion

### DIFF
--- a/docs/howto/advanced/cancellation.md
+++ b/docs/howto/advanced/cancellation.md
@@ -69,4 +69,9 @@ async def my_task(context):
 `context.should_abort()` and `context.should_abort_async()` does poll the
 database and might flood the database. Ensure you do it only sometimes and
 not from too many parallel tasks.
+
+You can use an optional `cache` parameter for limiting the frequency of
+database requests. For example, calling `context.should_abort(cache=10)` resp.
+`await context.should_abort_async(cache=10)` will reuse the cached status for
+the specified number of seconds without polling the database.
 :::

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -39,7 +39,8 @@ When tasks are created with argument ``pass_context``, they are provided a
 `JobContext` argument:
 
 .. autoclass:: procrastinate.JobContext
-    :members: app, worker_name, worker_queues, job, task
+    :members: app, worker_name, worker_queues, job, task,
+              should_abort, should_abort_async
 
 Blueprints
 ----------


### PR DESCRIPTION
Closes #1083 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help, too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

I am not fully convinced that setting a default cache time on the worker itself is a good idea - it's a bit too much intransparent magic for my taste. Users may have completely different ideas about how long such a cache period should be (depending on the duration of the task itself).