### PR TITLE
Set job to failed when task raises and job is aborting (regardless retry)

### DIFF
--- a/docs/howto/advanced/cancellation.md
+++ b/docs/howto/advanced/cancellation.md
@@ -70,3 +70,8 @@ async def my_task(context):
 database and might flood the database. Ensure you do it only sometimes and
 not from too many parallel tasks.
 :::
+
+:::{note}
+When a task of a job that was requested to be aborted raises an error, the job
+is marked as failed (regardless of the retry strategy).
+:::

--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -145,3 +145,22 @@ async def test_abort(async_app):
 
     status = await async_app.job_manager.get_job_status_async(job2_id)
     assert status == Status.ABORTED
+
+
+async def test_retry_when_aborting(async_app):
+    attempts = 0
+
+    @async_app.task(queue="default", name="task1", pass_context=True, retry=True)
+    async def example_task(context):
+        nonlocal attempts
+        attempts += 1
+        await async_app.job_manager.cancel_job_by_id_async(context.job.id, abort=True)
+        raise ValueError()
+
+    job_id = await example_task.defer_async()
+
+    await async_app.run_worker_async(queues=["default"], wait=False)
+
+    status = await async_app.job_manager.get_job_status_async(job_id)
+    assert status == Status.FAILED
+    assert attempts == 1

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -366,7 +366,7 @@ async def test_run_job_aborted(app, caplog):
     )
 
 
-async def test_run_job_error(app, caplog):
+async def test_run_job_error(app, caplog, mocker):
     caplog.set_level("INFO")
 
     def job_func(a, b):  # pylint: disable=unused-argument
@@ -385,6 +385,7 @@ async def test_run_job_error(app, caplog):
         task_name="job",
         queue="yay",
     )
+    app.job_manager.get_job_status_async = mocker.AsyncMock(return_value="doing")
     test_worker = worker.Worker(app, queues=["yay"])
     with pytest.raises(exceptions.JobError):
         await test_worker.run_job(job=job, worker_id=3)
@@ -401,7 +402,7 @@ async def test_run_job_error(app, caplog):
     )
 
 
-async def test_run_job_critical_error(app, caplog):
+async def test_run_job_critical_error(app, caplog, mocker):
     caplog.set_level("INFO")
 
     def job_func(a, b):  # pylint: disable=unused-argument
@@ -420,6 +421,7 @@ async def test_run_job_critical_error(app, caplog):
         task_name="job",
         queue="yay",
     )
+    app.job_manager.get_job_status_async = mocker.AsyncMock(return_value="doing")
     test_worker = worker.Worker(app, queues=["yay"])
     with pytest.raises(exceptions.JobError) as exc_info:
         await test_worker.run_job(job=job, worker_id=3)
@@ -427,7 +429,7 @@ async def test_run_job_critical_error(app, caplog):
     assert exc_info.value.critical is True
 
 
-async def test_run_job_retry(app, caplog):
+async def test_run_job_retry(app, caplog, mocker):
     caplog.set_level("INFO")
 
     def job_func(a, b):  # pylint: disable=unused-argument
@@ -446,6 +448,7 @@ async def test_run_job_retry(app, caplog):
         queueing_lock="houba",
         queue="yay",
     )
+    app.job_manager.get_job_status_async = mocker.AsyncMock(return_value="doing")
     test_worker = worker.Worker(app, queues=["yay"])
     with pytest.raises(exceptions.JobError) as exc_info:
         await test_worker.run_job(job=job, worker_id=3)


### PR DESCRIPTION
Closes #1131

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

This time, a job with the status `aborting` of a task that raises is set to `failed` (regardless of whether it should be retried or not). It feels a bit more consistent to me, but somehow, there is no optimal way. If we set a to-be-retried job in status `aborting` to `aborted` when the task raises, but one to `failed` that should not be retried, it seems somehow inconsistent to me.

@ewjoachim A note in the documentation is still missing. Just want to hear what you think.