### PR TITLE
feat: allow cleaning of cancelled and aborted jobs

### DIFF
--- a/docs/howto/production/delete_finished_jobs.md
+++ b/docs/howto/production/delete_finished_jobs.md
@@ -88,6 +88,8 @@ async def remove_old_jobs(context, timestamp):
         context,
         max_hours=72,
         remove_error=True,
+        remove_cancelled=True,
+        remove_aborted=True,
     )
 ```
 

--- a/procrastinate/builtin_tasks.py
+++ b/procrastinate/builtin_tasks.py
@@ -12,6 +12,8 @@ async def remove_old_jobs(
     max_hours: int,
     queue: str | None = None,
     remove_error: bool | None = False,
+    remove_cancelled: bool | None = False,
+    remove_aborted: bool | None = False,
 ) -> None:
     """
     This task cleans your database by removing old jobs. Note that jobs and linked
@@ -24,11 +26,21 @@ async def remove_old_jobs(
     queue :
         The name of the queue in which jobs will be deleted. If not specified, the
         task will delete jobs from all queues.
-    remove_error :
+    remove_error : ``Optional[bool]``
         By default only successful jobs will be removed. When this parameter is True
         failed jobs will also be deleted.
+    remove_cancelled : ``Optional[bool]``
+        By default only successful jobs will be removed. When this parameter is True
+        cancelled jobs will also be deleted.
+    remove_aborted : ``Optional[bool]``
+        By default only successful jobs will be removed. When this parameter is True
+        aborted jobs will also be deleted.
     """
     assert context.app
     await context.app.job_manager.delete_old_jobs(
-        nb_hours=max_hours, queue=queue, include_error=remove_error
+        nb_hours=max_hours,
+        queue=queue,
+        include_error=remove_error,
+        include_cancelled=remove_cancelled,
+        include_aborted=remove_aborted,
     )

--- a/tests/unit/test_builtin_tasks.py
+++ b/tests/unit/test_builtin_tasks.py
@@ -5,11 +5,20 @@ from procrastinate import builtin_tasks, job_context
 
 async def test_remove_old_jobs(app):
     await builtin_tasks.remove_old_jobs(
-        job_context.JobContext(app=app), max_hours=2, queue="queue_a", remove_error=True
+        job_context.JobContext(app=app),
+        max_hours=2,
+        queue="queue_a",
+        remove_error=True,
+        remove_cancelled=True,
+        remove_aborted=True,
     )
     assert app.connector.queries == [
         (
             "delete_old_jobs",
-            {"nb_hours": 2, "queue": "queue_a", "statuses": ["succeeded", "failed"]},
+            {
+                "nb_hours": 2,
+                "queue": "queue_a",
+                "statuses": ["succeeded", "failed", "cancelled", "aborted"],
+            },
         )
     ]


### PR DESCRIPTION
Adds additional parameters to the builtin remove_old_jobs task to allow removing cancelled and aborted jobs in addition to failed and succeeded. Closes #1145.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
