### PR TITLE
Async InMemoryConnector (testing)

### DIFF
--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -50,7 +50,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
     def get_sync_connector(self) -> connector.BaseConnector:
         return self
 
-    def generic_execute(self, query, suffix, **arguments) -> Any:
+    async def generic_execute(self, query, suffix, **arguments) -> Any:
         """
         Calling a query will call the <query_name>_<suffix> method
         on this class. Suffix is "run" if no result is expected,
@@ -58,32 +58,23 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         """
         query_name = self.reverse_queries[query]
         self.queries.append((query_name, arguments))
-        return getattr(self, f"{query_name}_{suffix}")(**arguments)
+        return await getattr(self, f"{query_name}_{suffix}")(**arguments)
 
     def make_dynamic_query(self, query, **identifiers: str) -> str:
         return query.format(**identifiers)
 
-    def execute_query(self, query: str, **arguments: Any) -> None:
-        self.generic_execute(query, "run", **arguments)
-
-    def execute_query_one(self, query: str, **arguments: Any) -> dict[str, Any]:
-        return self.generic_execute(query, "one", **arguments)
-
-    def execute_query_all(self, query: str, **arguments: Any) -> list[dict[str, Any]]:
-        return self.generic_execute(query, "all", **arguments)
-
     async def execute_query_async(self, query: str, **arguments: Any) -> None:
-        self.generic_execute(query, "run", **arguments)
+        await self.generic_execute(query, "run", **arguments)
 
     async def execute_query_one_async(
         self, query: str, **arguments: Any
     ) -> dict[str, Any]:
-        return self.generic_execute(query, "one", **arguments)
+        return await self.generic_execute(query, "one", **arguments)
 
     async def execute_query_all_async(
         self, query: str, **arguments: Any
     ) -> list[dict[str, Any]]:
-        return self.generic_execute(query, "all", **arguments)
+        return await self.generic_execute(query, "all", **arguments)
 
     async def listen_notify(
         self, event: asyncio.Event, channels: Iterable[str]
@@ -105,7 +96,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
 
     # End of BaseConnector methods
 
-    def defer_job_one(
+    async def defer_job_one(
         self,
         task_name: str,
         priority: int,
@@ -151,7 +142,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
                 self.notify_event.set()
         return job_row
 
-    def defer_periodic_job_one(
+    async def defer_periodic_job_one(
         self,
         queue: str,
         task_name: str,
@@ -167,7 +158,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
             return {"id": None}
 
         self.periodic_defers[(task_name, periodic_id)] = defer_timestamp
-        return self.defer_job_one(
+        return await self.defer_job_one(
             task_name=task_name,
             queue=queue,
             priority=priority,
@@ -191,7 +182,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
             if job["status"] in {"failed", "succeeded"}
         ]
 
-    def fetch_job_one(self, queues: Iterable[str] | None) -> dict:
+    async def fetch_job_one(self, queues: Iterable[str] | None) -> dict:
         # Creating a copy of the iterable so that we can modify it while we iterate
 
         filtered_jobs = [
@@ -215,7 +206,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         self.events[job["id"]].append({"type": "started", "at": utils.utcnow()})
         return job
 
-    def finish_job_run(self, job_id: int, status: str, delete_job: bool) -> None:
+    async def finish_job_run(self, job_id: int, status: str, delete_job: bool) -> None:
         if delete_job:
             self.jobs.pop(job_id)
             return
@@ -226,7 +217,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         job_row["abort_requested"] = False
         self.events[job_id].append({"type": status, "at": utils.utcnow()})
 
-    def cancel_job_one(self, job_id: int, abort: bool, delete_job: bool) -> dict:
+    async def cancel_job_one(self, job_id: int, abort: bool, delete_job: bool) -> dict:
         job_row = self.jobs[job_id]
 
         if job_row["status"] == "todo":
@@ -243,13 +234,13 @@ class InMemoryConnector(connector.BaseAsyncConnector):
 
         return {"id": None}
 
-    def get_job_status_one(self, job_id: int) -> dict:
+    async def get_job_status_one(self, job_id: int) -> dict:
         return {"status": self.jobs[job_id]["status"]}
 
-    def get_job_abort_requested_one(self, job_id: int) -> dict:
+    async def get_job_abort_requested_one(self, job_id: int) -> dict:
         return {"abort_requested": self.jobs[job_id]["abort_requested"]}
 
-    def retry_job_run(
+    async def retry_job_run(
         self,
         job_id: int,
         retry_at: datetime.datetime,
@@ -270,7 +261,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         self.events[job_id].append({"type": "scheduled", "at": retry_at})
         self.events[job_id].append({"type": "deferred_for_retry", "at": utils.utcnow()})
 
-    def select_stalled_jobs_all(self, nb_seconds, queue, task_name):
+    async def select_stalled_jobs_all(self, nb_seconds, queue, task_name):
         return (
             job
             for job in self.jobs.values()
@@ -281,7 +272,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
             and task_name in (job["task_name"], None)
         )
 
-    def delete_old_jobs_run(self, nb_hours, queue, statuses):
+    async def delete_old_jobs_run(self, nb_hours, queue, statuses):
         for id, job in list(self.jobs.items()):
             if (
                 job["status"] in statuses
@@ -293,47 +284,57 @@ class InMemoryConnector(connector.BaseAsyncConnector):
             ):
                 self.jobs.pop(id)
 
-    def listen_for_jobs_run(self) -> None:
+    async def listen_for_jobs_run(self) -> None:
         pass
 
-    def apply_schema_run(self) -> None:
+    async def apply_schema_run(self) -> None:
         pass
 
-    def list_jobs_all(self, **kwargs):
+    async def list_jobs_all(self, **kwargs):
+        jobs: list[JobRow] = []
         for job in self.jobs.values():
             if all(
                 expected is None or str(job[key]) == str(expected)
                 for key, expected in kwargs.items()
             ):
-                yield job
+                jobs.append(job)
+        return iter(jobs)
 
-    def list_queues_all(self, **kwargs):
-        jobs = list(self.list_jobs_all(**kwargs))
+    async def list_queues_all(self, **kwargs):
+        result: list[dict] = []
+        jobs = list(await self.list_jobs_all(**kwargs))
         queues = sorted({job["queue_name"] for job in jobs})
         for queue in queues:
             queue_jobs = [job for job in jobs if job["queue_name"] == queue]
             stats = Counter(job["status"] for job in queue_jobs)
-            yield {"name": queue, "jobs_count": len(queue_jobs), "stats": stats}
+            result.append(
+                {"name": queue, "jobs_count": len(queue_jobs), "stats": stats}
+            )
+        return iter(result)
 
-    def list_tasks_all(self, **kwargs):
-        jobs = list(self.list_jobs_all(**kwargs))
+    async def list_tasks_all(self, **kwargs):
+        result: list[dict] = []
+        jobs = list(await self.list_jobs_all(**kwargs))
         tasks = sorted({job["task_name"] for job in jobs})
         for task in tasks:
             task_jobs = [job for job in jobs if job["task_name"] == task]
             stats = Counter(job["status"] for job in task_jobs)
-            yield {"name": task, "jobs_count": len(task_jobs), "stats": stats}
+            result.append({"name": task, "jobs_count": len(task_jobs), "stats": stats})
+        return result
 
-    def list_locks_all(self, **kwargs):
-        jobs = list(self.list_jobs_all(**kwargs))
+    async def list_locks_all(self, **kwargs):
+        result: list[dict] = []
+        jobs = list(await self.list_jobs_all(**kwargs))
         locks = sorted({job["lock"] for job in jobs})
         for lock in locks:
             lock_jobs = [job for job in jobs if job["lock"] == lock]
             stats = Counter(job["status"] for job in lock_jobs)
-            yield {"name": lock, "jobs_count": len(lock_jobs), "stats": stats}
+            result.append({"name": lock, "jobs_count": len(lock_jobs), "stats": stats})
+        return result
 
-    def set_job_status_run(self, id, status):
+    async def set_job_status_run(self, id, status):
         id = int(id)
         self.jobs[id]["status"] = status
 
-    def check_connection_one(self):
+    async def check_connection_one(self):
         return {"check": self.table_exists or None}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def blueprint():
 
 
 @pytest.fixture
-def job_manager(app):
+def job_manager(app: app_module.App):
     return app.job_manager
 
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -285,7 +285,7 @@ async def test_defer_queueing_lock_ignore(entrypoint, cli_app, connector):
     def mytask(a):
         pass
 
-    cli_app.configure_task(name="hello", queueing_lock="houba").defer(a=1)
+    await cli_app.configure_task(name="hello", queueing_lock="houba").defer_async(a=1)
 
     result = await entrypoint(
         """defer --queueing-lock=houba --ignore-already-enqueued hello {"a":2}"""

--- a/tests/unit/test_job_context.py
+++ b/tests/unit/test_job_context.py
@@ -75,7 +75,6 @@ async def test_should_abort(app, job_factory):
     job = await app.job_manager.fetch_job(queues=None)
     await app.job_manager.cancel_job_by_id_async(job.id, abort=True)
     context = job_context.JobContext(app=app, job=job)
-    assert context.should_abort() is True
     assert await context.should_abort_async() is True
 
 
@@ -84,5 +83,4 @@ async def test_should_not_abort(app, job_factory):
     job = await app.job_manager.fetch_job(queues=None)
     await app.job_manager.cancel_job_by_id_async(job.id)
     context = job_context.JobContext(app=app, job=job)
-    assert context.should_abort() is False
     assert await context.should_abort_async() is False

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -231,7 +231,7 @@ async def test_cancel_doing_job(job_manager, job_factory, connector):
     await job_manager.defer_job_async(job=job)
     await job_manager.fetch_job(queues=None)
 
-    cancelled = job_manager.cancel_job_by_id(job_id=1)
+    cancelled = await job_manager.cancel_job_by_id_async(job_id=1)
     assert not cancelled
     assert connector.queries[-1] == (
         "cancel_job",
@@ -245,7 +245,7 @@ async def test_abort_doing_job(job_manager, job_factory, connector):
     await job_manager.defer_job_async(job=job)
     await job_manager.fetch_job(queues=None)
 
-    cancelled = job_manager.cancel_job_by_id(job_id=1, abort=True)
+    cancelled = await job_manager.cancel_job_by_id_async(job_id=1, abort=True)
     assert cancelled
     assert connector.queries[-1] == (
         "cancel_job",
@@ -445,7 +445,7 @@ def test_retry_job_by_id(job_manager, connector, job_factory, dt):
 
 
 async def test_list_jobs_async(job_manager, job_factory):
-    job = job_manager.defer_job(job=job_factory())
+    job = await job_manager.defer_job_async(job=job_factory())
 
     assert await job_manager.list_jobs_async() == [job]
 
@@ -457,7 +457,7 @@ def test_list_jobs(job_manager, job_factory):
 
 
 async def test_list_queues_async(job_manager, job_factory):
-    job_manager.defer_job(job=job_factory(queue="foo"))
+    await job_manager.defer_job_async(job=job_factory(queue="foo"))
 
     assert await job_manager.list_queues_async() == [
         {
@@ -491,7 +491,7 @@ def test_list_queues_(job_manager, job_factory):
 
 
 async def test_list_tasks_async(job_manager, job_factory):
-    job_manager.defer_job(job=job_factory(task_name="foo"))
+    await job_manager.defer_job_async(job=job_factory(task_name="foo"))
 
     assert await job_manager.list_tasks_async() == [
         {
@@ -525,7 +525,7 @@ def test_list_tasks(job_manager, job_factory):
 
 
 async def test_list_locks_async(job_manager, job_factory):
-    job_manager.defer_job(job=job_factory(lock="foo"))
+    await job_manager.defer_job_async(job=job_factory(lock="foo"))
 
     assert await job_manager.list_locks_async() == [
         {

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from procrastinate import manager
@@ -22,23 +24,27 @@ def test_EOF(shell):
 
 
 def test_list_jobs(shell, connector, capsys):
-    connector.defer_job_one(
-        "task1",
-        0,
-        "lock1",
-        "queueing_lock1",
-        {},
-        conftest.aware_datetime(2000, 1, 1),
-        "queue1",
+    asyncio.run(
+        connector.defer_job_one(
+            "task1",
+            0,
+            "lock1",
+            "queueing_lock1",
+            {},
+            conftest.aware_datetime(2000, 1, 1),
+            "queue1",
+        )
     )
-    connector.defer_job_one(
-        "task2",
-        0,
-        "lock2",
-        "queueing_lock2",
-        {},
-        conftest.aware_datetime(2000, 1, 1),
-        "queue2",
+    asyncio.run(
+        connector.defer_job_one(
+            "task2",
+            0,
+            "lock2",
+            "queueing_lock2",
+            {},
+            conftest.aware_datetime(2000, 1, 1),
+            "queue2",
+        )
     )
 
     shell.do_list_jobs("")
@@ -63,23 +69,27 @@ def test_list_jobs(shell, connector, capsys):
 
 
 def test_list_jobs_filters(shell, connector, capsys):
-    connector.defer_job_one(
-        "task1",
-        0,
-        "lock1",
-        "queueing_lock1",
-        {},
-        conftest.aware_datetime(2000, 1, 1),
-        "queue1",
+    asyncio.run(
+        connector.defer_job_one(
+            "task1",
+            0,
+            "lock1",
+            "queueing_lock1",
+            {},
+            conftest.aware_datetime(2000, 1, 1),
+            "queue1",
+        )
     )
-    connector.defer_job_one(
-        "task2",
-        0,
-        "lock2",
-        "queueing_lock2",
-        {},
-        conftest.aware_datetime(2000, 1, 1),
-        "queue2",
+    asyncio.run(
+        connector.defer_job_one(
+            "task2",
+            0,
+            "lock2",
+            "queueing_lock2",
+            {},
+            conftest.aware_datetime(2000, 1, 1),
+            "queue2",
+        )
     )
 
     shell.do_list_jobs("id=2 queue=queue2 task=task2 lock=lock2 status=todo")
@@ -103,23 +113,27 @@ def test_list_jobs_filters(shell, connector, capsys):
 
 
 def test_list_jobs_details(shell, connector, capsys):
-    connector.defer_job_one(
-        "task1",
-        5,
-        "lock1",
-        "queueing_lock1",
-        {"x": 11},
-        conftest.aware_datetime(1000, 1, 1),
-        "queue1",
+    asyncio.run(
+        connector.defer_job_one(
+            "task1",
+            5,
+            "lock1",
+            "queueing_lock1",
+            {"x": 11},
+            conftest.aware_datetime(1000, 1, 1),
+            "queue1",
+        )
     )
-    connector.defer_job_one(
-        "task2",
-        7,
-        "lock2",
-        "queueing_lock2",
-        {"y": 22},
-        conftest.aware_datetime(2000, 1, 1),
-        "queue2",
+    asyncio.run(
+        connector.defer_job_one(
+            "task2",
+            7,
+            "lock2",
+            "queueing_lock2",
+            {"y": 22},
+            conftest.aware_datetime(2000, 1, 1),
+            "queue2",
+        )
     )
 
     shell.do_list_jobs("details")
@@ -139,8 +153,12 @@ def test_list_jobs_empty(shell, connector, capsys):
 
 
 def test_list_queues(shell, connector, capsys):
-    connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
-    connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    asyncio.run(
+        connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
+    )
+    asyncio.run(
+        connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    )
 
     shell.do_list_queues("")
     captured = capsys.readouterr()
@@ -157,8 +175,12 @@ def test_list_queues(shell, connector, capsys):
 
 
 def test_list_queues_filters(shell, connector, capsys):
-    connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
-    connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    asyncio.run(
+        connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
+    )
+    asyncio.run(
+        connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    )
 
     shell.do_list_queues("queue=queue2 task=task2 lock=lock2 status=todo")
     captured = capsys.readouterr()
@@ -185,8 +207,12 @@ def test_list_queues_empty(shell, connector, capsys):
 
 
 def test_list_tasks(shell, connector, capsys):
-    connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
-    connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    asyncio.run(
+        connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
+    )
+    asyncio.run(
+        connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    )
 
     shell.do_list_tasks("")
     captured = capsys.readouterr()
@@ -203,8 +229,12 @@ def test_list_tasks(shell, connector, capsys):
 
 
 def test_list_tasks_filters(shell, connector, capsys):
-    connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
-    connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    asyncio.run(
+        connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
+    )
+    asyncio.run(
+        connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    )
 
     shell.do_list_tasks("queue=queue2 task=task2 lock=lock2 status=todo")
     captured = capsys.readouterr()
@@ -231,8 +261,12 @@ def test_list_tasks_empty(shell, connector, capsys):
 
 
 def test_list_locks(shell, connector, capsys):
-    connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
-    connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    asyncio.run(
+        connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
+    )
+    asyncio.run(
+        connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    )
 
     shell.do_list_locks("")
     captured = capsys.readouterr()
@@ -249,8 +283,12 @@ def test_list_locks(shell, connector, capsys):
 
 
 def test_list_locks_filters(shell, connector, capsys):
-    connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
-    connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    asyncio.run(
+        connector.defer_job_one("task1", 0, "lock1", "queueing_lock1", {}, 0, "queue1")
+    )
+    asyncio.run(
+        connector.defer_job_one("task2", 0, "lock2", "queueing_lock2", {}, 0, "queue2")
+    )
 
     shell.do_list_locks("queue=queue2 task=task2 lock=lock2 status=todo")
     captured = capsys.readouterr()
@@ -277,16 +315,18 @@ def test_list_locks_empty(shell, connector, capsys):
 
 
 def test_retry(shell, connector, capsys):
-    connector.defer_job_one(
-        "task",
-        0,
-        "lock",
-        "queueing_lock",
-        {},
-        conftest.aware_datetime(2000, 1, 1),
-        "queue",
+    asyncio.run(
+        connector.defer_job_one(
+            "task",
+            0,
+            "lock",
+            "queueing_lock",
+            {},
+            conftest.aware_datetime(2000, 1, 1),
+            "queue",
+        )
     )
-    connector.set_job_status_run(1, "failed")
+    asyncio.run(connector.set_job_status_run(1, "failed"))
 
     shell.do_list_jobs("id=1")
     captured = capsys.readouterr()
@@ -298,14 +338,16 @@ def test_retry(shell, connector, capsys):
 
 
 def test_cancel(shell, connector, capsys):
-    connector.defer_job_one(
-        "task",
-        0,
-        "lock",
-        "queueing_lock",
-        {},
-        conftest.aware_datetime(2000, 1, 1),
-        "queue",
+    asyncio.run(
+        connector.defer_job_one(
+            "task",
+            0,
+            "lock",
+            "queueing_lock",
+            {},
+            conftest.aware_datetime(2000, 1, 1),
+            "queue",
+        )
     )
 
     shell.do_list_jobs("id=1")

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -15,28 +16,28 @@ def test_reset(connector):
     assert connector.jobs == {}
 
 
-def test_generic_execute(connector):
+async def test_generic_execute(connector):
     result = {}
     connector.reverse_queries = {"a": "b"}
 
-    def b(**kwargs):
+    async def b(**kwargs):
         result.update(kwargs)
 
     connector.b_youpi = b
 
-    connector.generic_execute("a", "youpi", i="j")
+    await connector.generic_execute("a", "youpi", i="j")
 
     assert result == {"i": "j"}
 
 
-async def test_execute_query(connector, mocker):
-    connector.generic_execute = mocker.Mock()
+async def test_execute_query(connector):
+    connector.generic_execute = AsyncMock()
     await connector.execute_query_async("a", b="c")
     connector.generic_execute.assert_called_with("a", "run", b="c")
 
 
-async def test_execute_query_one(connector, mocker):
-    connector.generic_execute = mocker.Mock()
+async def test_execute_query_one(connector):
+    connector.generic_execute = AsyncMock()
     assert (
         await connector.execute_query_one_async("a", b="c")
         == connector.generic_execute.return_value
@@ -44,8 +45,8 @@ async def test_execute_query_one(connector, mocker):
     connector.generic_execute.assert_called_with("a", "one", b="c")
 
 
-async def test_execute_query_all_async(connector, mocker):
-    connector.generic_execute = mocker.Mock()
+async def test_execute_query_all_async(connector):
+    connector.generic_execute = AsyncMock()
     assert (
         await connector.execute_query_all_async("a", b="c")
         == connector.generic_execute.return_value
@@ -57,8 +58,8 @@ def test_make_dynamic_query(connector):
     assert connector.make_dynamic_query("foo {bar}", bar="baz") == "foo baz"
 
 
-def test_defer_job_one(connector):
-    job = connector.defer_job_one(
+async def test_defer_job_one(connector):
+    job = await connector.defer_job_one(
         task_name="mytask",
         priority=5,
         lock="sher",
@@ -86,8 +87,8 @@ def test_defer_job_one(connector):
     assert connector.jobs[1] == job
 
 
-def test_defer_job_one_multiple_times(connector):
-    connector.defer_job_one(
+async def test_defer_job_one_multiple_times(connector):
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         lock=None,
@@ -96,7 +97,7 @@ def test_defer_job_one_multiple_times(connector):
         scheduled_at=None,
         queue="default",
     )
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         lock=None,
@@ -108,7 +109,7 @@ def test_defer_job_one_multiple_times(connector):
     assert len(connector.jobs) == 2
 
 
-def test_defer_same_job_with_queueing_lock_second_time_after_first_one_succeeded(
+async def test_defer_same_job_with_queueing_lock_second_time_after_first_one_succeeded(
     connector,
 ):
     job_data = {
@@ -122,21 +123,23 @@ def test_defer_same_job_with_queueing_lock_second_time_after_first_one_succeeded
     }
 
     # 1. Defer job with queueing-lock
-    job_row = connector.defer_job_one(**job_data)
+    job_row = await connector.defer_job_one(**job_data)
     assert len(connector.jobs) == 1
 
     # 2. Defering a second time should fail, as first one
     #    still in state `todo`
     with pytest.raises(exceptions.UniqueViolation):
-        connector.defer_job_one(**job_data)
+        await connector.defer_job_one(**job_data)
     assert len(connector.jobs) == 1
 
     # 3. Finish first job
-    connector.finish_job_run(job_id=job_row["id"], status="finished", delete_job=False)
+    await connector.finish_job_run(
+        job_id=job_row["id"], status="finished", delete_job=False
+    )
 
     # 4. Defering a second time should work now,
     #    as first job in state `finished`
-    connector.defer_job_one(**job_data)
+    await connector.defer_job_one(**job_data)
     assert len(connector.jobs) == 2
 
 
@@ -158,7 +161,7 @@ def test_finished_jobs(connector):
     assert connector.finished_jobs == [{"status": "succeeded"}, {"status": "failed"}]
 
 
-def test_select_stalled_jobs_all(connector):
+async def test_select_stalled_jobs_all(connector):
     connector.jobs = {
         # We're not selecting this job because it's "succeeded"
         1: {
@@ -212,13 +215,13 @@ def test_select_stalled_jobs_all(connector):
         6: [{"at": conftest.aware_datetime(2000, 1, 1)}],
     }
 
-    results = connector.select_stalled_jobs_all(
+    results = await connector.select_stalled_jobs_all(
         queue="marsupilami", task_name="mytask", nb_seconds=0
     )
     assert [job["id"] for job in results] == [5, 6]
 
 
-def test_delete_old_jobs_run(connector):
+async def test_delete_old_jobs_run(connector):
     connector.jobs = {
         # We're not deleting this job because it's "doing"
         1: {"id": 1, "status": "doing", "queue_name": "marsupilami"},
@@ -236,15 +239,15 @@ def test_delete_old_jobs_run(connector):
         4: [{"type": "succeeded", "at": conftest.aware_datetime(2000, 1, 1)}],
     }
 
-    connector.delete_old_jobs_run(
+    await connector.delete_old_jobs_run(
         queue="marsupilami", statuses=("succeeded"), nb_hours=0
     )
     assert 4 not in connector.jobs
 
 
-def test_fetch_job_one(connector):
+async def test_fetch_job_one(connector):
     # This one will be selected, then skipped the second time because it's processing
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         args={},
@@ -255,7 +258,7 @@ def test_fetch_job_one(connector):
     )
 
     # This one because it's the wrong queue
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         args={},
@@ -265,7 +268,7 @@ def test_fetch_job_one(connector):
         queueing_lock="b",
     )
     # This one because of the scheduled_at
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         args={},
@@ -275,7 +278,7 @@ def test_fetch_job_one(connector):
         queueing_lock="c",
     )
     # This one because of the lock
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         args={},
@@ -285,7 +288,7 @@ def test_fetch_job_one(connector):
         queueing_lock="d",
     )
     # We're taking this one.
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         args={},
@@ -295,13 +298,13 @@ def test_fetch_job_one(connector):
         queueing_lock="e",
     )
 
-    assert connector.fetch_job_one(queues=["marsupilami"])["id"] == 1
-    assert connector.fetch_job_one(queues=["marsupilami"])["id"] == 5
+    assert (await connector.fetch_job_one(queues=["marsupilami"]))["id"] == 1
+    assert (await connector.fetch_job_one(queues=["marsupilami"]))["id"] == 5
 
 
-def test_fetch_job_one_prioritized(connector):
+async def test_fetch_job_one_prioritized(connector):
     # This one will be selected second as it has a lower priority
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=5,
         args={},
@@ -312,7 +315,7 @@ def test_fetch_job_one_prioritized(connector):
     )
 
     # This one will be selected first as it has a higher priority
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=7,
         args={},
@@ -322,13 +325,13 @@ def test_fetch_job_one_prioritized(connector):
         queueing_lock=None,
     )
 
-    assert connector.fetch_job_one(queues=None)["id"] == 2
-    assert connector.fetch_job_one(queues=None)["id"] == 1
+    assert (await connector.fetch_job_one(queues=None))["id"] == 2
+    assert (await connector.fetch_job_one(queues=None))["id"] == 1
 
 
-def test_fetch_job_one_none_lock(connector):
+async def test_fetch_job_one_none_lock(connector):
     """Testing that 2 jobs with locks "None" don't block one another"""
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         args={},
@@ -337,7 +340,7 @@ def test_fetch_job_one_none_lock(connector):
         lock=None,
         queueing_lock=None,
     )
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         args={},
@@ -347,12 +350,12 @@ def test_fetch_job_one_none_lock(connector):
         queueing_lock=None,
     )
 
-    assert connector.fetch_job_one(queues=None)["id"] == 1
-    assert connector.fetch_job_one(queues=None)["id"] == 2
+    assert (await connector.fetch_job_one(queues=None))["id"] == 1
+    assert (await connector.fetch_job_one(queues=None))["id"] == 2
 
 
-def test_finish_job_run(connector):
-    connector.defer_job_one(
+async def test_finish_job_run(connector):
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         args={},
@@ -361,17 +364,17 @@ def test_finish_job_run(connector):
         lock="sher",
         queueing_lock="houba",
     )
-    job_row = connector.fetch_job_one(queues=None)
+    job_row = await connector.fetch_job_one(queues=None)
     id = job_row["id"]
 
-    connector.finish_job_run(job_id=id, status="finished", delete_job=False)
+    await connector.finish_job_run(job_id=id, status="finished", delete_job=False)
 
     assert connector.jobs[id]["attempts"] == 1
     assert connector.jobs[id]["status"] == "finished"
 
 
-def test_retry_job_run(connector):
-    connector.defer_job_one(
+async def test_retry_job_run(connector):
+    await connector.defer_job_one(
         task_name="mytask",
         priority=0,
         args={},
@@ -380,11 +383,11 @@ def test_retry_job_run(connector):
         lock="sher",
         queueing_lock="houba",
     )
-    job_row = connector.fetch_job_one(queues=None)
+    job_row = await connector.fetch_job_one(queues=None)
     id = job_row["id"]
 
     retry_at = conftest.aware_datetime(2000, 1, 1)
-    connector.retry_job_run(
+    await connector.retry_job_run(
         job_id=id,
         retry_at=retry_at,
         new_priority=3,
@@ -401,14 +404,14 @@ def test_retry_job_run(connector):
     assert len(connector.events[id]) == 4
 
 
-def test_apply_schema_run(connector):
+async def test_apply_schema_run(connector):
     # If we don't crash, it's enough
-    connector.apply_schema_run()
+    await connector.apply_schema_run()
 
 
-def test_listen_for_jobs_run(connector):
+async def test_listen_for_jobs_run(connector):
     # If we don't crash, it's enough
-    connector.listen_for_jobs_run()
+    await connector.listen_for_jobs_run()
 
 
 async def test_defer_no_notify(connector):
@@ -416,7 +419,7 @@ async def test_defer_no_notify(connector):
     # listened queue, the testing connector doesn't notify.
     event = asyncio.Event()
     await connector.listen_notify(event=event, channels="some_other_channel")
-    connector.defer_job_one(
+    await connector.defer_job_one(
         task_name="foo",
         priority=0,
         lock="bar",

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -125,8 +125,8 @@ async def test_worker_run_respects_concurrency(
 
     connector = cast(InMemoryConnector, app.connector)
 
-    doings_jobs = list(connector.list_jobs_all(status=Status.DOING.value))
-    todo_jobs = list(connector.list_jobs_all(status=Status.TODO.value))
+    doings_jobs = list(await connector.list_jobs_all(status=Status.DOING.value))
+    todo_jobs = list(await connector.list_jobs_all(status=Status.TODO.value))
 
     assert len(doings_jobs) == worker.concurrency
     assert len(todo_jobs) == available_jobs - worker.concurrency
@@ -390,7 +390,7 @@ async def test_run_job_async(app: App, worker):
     async def task_func(a, b):
         result.append(a + b)
 
-    job_id = task_func.defer(a=9, b=3)
+    job_id = await task_func.defer_async(a=9, b=3)
 
     await start_worker(worker)
     assert result == [12]
@@ -406,7 +406,7 @@ async def test_run_job_sync(app: App, worker):
     def task_func(a, b):
         result.append(a + b)
 
-    job_id = task_func.defer(a=9, b=3)
+    job_id = await task_func.defer_async(a=9, b=3)
 
     await start_worker(worker)
     assert result == [12]
@@ -425,7 +425,7 @@ async def test_run_job_semi_async(app: App, worker):
 
         return inner()
 
-    job_id = task_func.defer(a=9, b=3)
+    job_id = await task_func.defer_async(a=9, b=3)
 
     await start_worker(worker)
 
@@ -442,7 +442,7 @@ async def test_run_job_log_result(caplog, app: App, worker):
     async def task_func(a, b):
         return a + b
 
-    task_func.defer(a=9, b=3)
+    await task_func.defer_async(a=9, b=3)
 
     await start_worker(worker)
 
@@ -491,7 +491,7 @@ async def test_run_job_error(app: App, worker, critical_error, caplog):
     def task_func(a, b):
         raise CustomCriticalError("Nope") if critical_error else ValueError("Nope")
 
-    job_id = task_func.defer(a=9, b=3)
+    job_id = await task_func.defer_async(a=9, b=3)
 
     await start_worker(worker)
 
@@ -517,7 +517,7 @@ async def test_run_job_aborted(app: App, worker, caplog):
     async def task_func():
         raise JobAborted()
 
-    job_id = task_func.defer()
+    job_id = await task_func.defer_async()
 
     await start_worker(worker)
 
@@ -559,7 +559,7 @@ async def test_run_job_retry_failed_job(
         if attempt < recover_on_attempt_number:
             raise CustomCriticalError("Nope") if critical_error else ValueError("Nope")
 
-    job_id = task_func.defer()
+    job_id = await task_func.defer_async()
 
     await start_worker(worker)
 


### PR DESCRIPTION
<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


## Context

Today, the only supported type of channel notification is the insertion of a new job.

To support more types of notification (e.g. cancellation), the connector will need to interact with async subscribers.
To support awaiting async callbacks, some functions from the `InMemoryConnector` need to be async themselves. 

This is what the change is about. 
Some tests have been updated to avoid mixing sync and async operations because of nested `async_to_sync` calls. 


