### PR TITLE
Run sync task in its own thread

### DIFF
--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -105,7 +105,7 @@ async def sync_to_async(func: Callable[..., T], *args, **kwargs) -> T:
     Given a callable, return a callable that will call the original one in an
     async context.
     """
-    return await sync.sync_to_async(func)(*args, **kwargs)
+    return await sync.sync_to_async(func, thread_sensitive=False)(*args, **kwargs)
 
 
 def causes(exc: BaseException | None):


### PR DESCRIPTION
Closes #1124 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

As discussed in #1156, this may not be a breaking change but rather a fix for an issue, because synchronous tasks in concurrency mode currently don't run in parallel but consecutively.