### PR TITLE
Fix Django + cron using the wrong connector

### DIFF
--- a/docs/howto/advanced/sync_defer.md
+++ b/docs/howto/advanced/sync_defer.md
@@ -55,24 +55,6 @@ app = App(connector=SQLAlchemyPsycopg2Connector())
 app.open(engine)
 ```
 
-## Having multiple apps
-
-If you need to have multiple connectors interact with the tasks, you can
-create multiple synchronized apps with {py:meth}`App.with_connector`:
-
-```
-import procrastinate
-
-
-app = procrastinate.App(
-    connector=procrastinate.PsycopgConnector(...),
-)
-
-sync_app = app.with_connector(
-    connector=procrastinate.SyncPsycopgConnector(...),
-)
-```
-
 ## Procrastinate's automatic connector selection
 
 Async connectors are able to summon their synchronous counterpart when needed

--- a/docs/howto/django/scripts.md
+++ b/docs/howto/django/scripts.md
@@ -21,8 +21,8 @@ def main():
     django.setup()
     # By default, the app uses the Django database connection, which is unsuitable
     # for the worker.
-    app = app.with_connector(app.connector.get_worker_connector())
-    app.run_worker()
+    with app.replace_connector(app.connector.get_worker_connector()):
+        app.run_worker()
 
 if __name__ == "__main__":
     main()

--- a/docs/howto/production/testing.md
+++ b/docs/howto/production/testing.md
@@ -17,8 +17,8 @@ def app():
     # Replace the connector in the current app
     # Note that this fixture gives you the app back for covenience,
     # but it's the same instance as `my_app`.
-    with my_app.replace_connector(in_memory) as app_with_connector:
-        yield app_with_connector
+    with my_app.replace_connector(in_memory) as app:
+        yield app
 
 
 def test_my_task(app):

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -94,12 +94,18 @@ class App(blueprints.Blueprint):
 
         self._register_builtin_tasks()
 
-    def with_connector(self, connector: connector_module.BaseConnector) -> App:
+    def with_connector(
+        self,
+        connector: connector_module.BaseConnector,
+    ) -> App:
         """
         Create another app instance sychronized with this one, with a different
-        connector. For all things regarding periodic tasks, the original app
-        (and its original connector) will be used, even when the new app's
-        methods are used.
+        connector.
+
+        .. deprecated:: 2.14.0
+            Use `replace_connector` instead. Because this method creates a new
+            app that references the same tasks, and the task have a link
+            back to the app, using this method can lead to unexpected behavior.
 
         Parameters
         ----------
@@ -109,7 +115,7 @@ class App(blueprints.Blueprint):
         Returns
         -------
         :
-            A new compatible app.
+            A new app with the same tasks.
         """
         app = App(
             connector=connector,
@@ -126,6 +132,12 @@ class App(blueprints.Blueprint):
     ) -> Iterator[App]:
         """
         Replace the connector of the app while in the context block, then restore it.
+        The context variable is the same app as this method is called on.
+
+        >>> with app.replace_connector(new_connector) as app2:
+        ...    ...
+        ...    # app and app2 are the same object
+
 
         Parameters
         ----------
@@ -134,8 +146,8 @@ class App(blueprints.Blueprint):
 
         Yields
         -------
-        `App`
-            A new compatible app.
+        :
+            A context manager that yields the same app with the new connector.
         """
         old_connector = self.connector
         self.connector = connector

--- a/tests/integration/contrib/django/test_models.py
+++ b/tests/integration/contrib/django/test_models.py
@@ -111,12 +111,14 @@ async def test_procrastinate_periodic_defers(db):
         pass
 
     django_app = procrastinate.contrib.django.app
-    app = django_app.with_connector(django_app.connector.get_worker_connector())
-    async with app.open_async():
-        try:
-            await asyncio.wait_for(app.run_worker_async(), timeout=0.1)
-        except asyncio.TimeoutError:
-            pass
+    with django_app.replace_connector(
+        django_app.connector.get_worker_connector()
+    ) as app:
+        async with app.open_async():
+            try:
+                await asyncio.wait_for(app.run_worker_async(), timeout=0.1)
+            except asyncio.TimeoutError:
+                pass
 
     periodic_defers = []
     async for element in models.ProcrastinatePeriodicDefer.objects.values().all():


### PR DESCRIPTION
Closes #1158

We should not use `with_connector`. `replace_connector` is the way to go.
`with_connector` has been documented for ages so there's no hurry to remove it, but at least now, it's clear.

I'll need to think about whether this is testable but I'm really not sure.

This PR makes it so that we (almost) don't use with_connectors anymore.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
