### PR TITLE
Add support for abort notification

### DIFF
--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -270,22 +270,33 @@ class App(blueprints.Blueprint):
             Name of the worker. Will be passed in the `JobContext` and used in the
             logs (defaults to ``None`` which will result in the worker named
             ``worker``).
-        polling_interval: ``float``
-            Indicates the maximum duration (in seconds) the worker waits between
-            each database job poll. Raising this parameter can lower the rate at which
-            the worker makes queries to the database for requesting jobs.
+        polling_interval : ``float``
+            Maximum time (in seconds) between database job polls.
+
+            Controls the frequency of database queries for:
+            - Checking for new jobs to start
+            - Fetching updates for running jobs
+            - Checking for abort requests
+
+            When `listen_notify` is True, the polling interval acts as a fallback
+            mechanism and can reasonably be set to a higher value.
+
             (defaults to 5.0)
         shutdown_timeout: ``float``
             Indicates the maximum duration (in seconds) the worker waits for jobs to
             complete when requested stop. Jobs that have not been completed by that time
             are aborted. A value of None corresponds to no timeout.
             (defaults to None)
-        listen_notify: ``bool``
-            If ``True``, the worker will dedicate a connection from the pool to
-            listening to database events, notifying of newly available jobs.
-            If ``False``, the worker will just poll the database periodically
-            (see ``polling_interval``). (defaults to ``True``)
-        delete_jobs: ``str``
+        listen_notify : ``bool``
+            If ``True``, allocates a connection from the pool to
+            listen for:
+            - new job availability
+            - job abort requests
+
+            Provides lower latency for job updates compared to polling alone.
+
+            Note: Worker polls the database regardless of this setting. (defaults to ``True``)
+        delete_jobs : ``str``
             If ``always``, the worker will automatically delete all jobs on completion.
             If ``successful`` the worker will only delete successful jobs.
             If ``never``, the worker will keep the jobs in the database.

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import asyncio
-from typing import Any, Callable, Iterable
+from typing import Any, Awaitable, Callable, Iterable, Protocol
 
 from typing_extensions import LiteralString
 
@@ -11,6 +10,10 @@ Pool = Any
 Engine = Any
 
 LISTEN_TIMEOUT = 30.0
+
+
+class Notify(Protocol):
+    def __call__(self, *, channel: str, payload: str) -> Awaitable[None]: ...
 
 
 class BaseConnector:
@@ -59,7 +62,9 @@ class BaseConnector:
         raise exceptions.SyncConnectorConfigurationError
 
     async def listen_notify(
-        self, event: asyncio.Event, channels: Iterable[str]
+        self,
+        on_notification: Notify,
+        channels: Iterable[str],
     ) -> None:
         raise exceptions.SyncConnectorConfigurationError
 
@@ -98,6 +103,6 @@ class BaseAsyncConnector(BaseConnector):
         return utils.async_to_sync(self.execute_query_all_async, query, **arguments)
 
     async def listen_notify(
-        self, event: asyncio.Event, channels: Iterable[str]
+        self, on_notification: Notify, channels: Iterable[str]
     ) -> None:
         raise NotImplementedError

--- a/procrastinate/contrib/aiopg/aiopg_connector.py
+++ b/procrastinate/contrib/aiopg/aiopg_connector.py
@@ -283,7 +283,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
 
     @wrap_exceptions()
     async def listen_notify(
-        self, event: asyncio.Event, channels: Iterable[str]
+        self, on_notification: connector.Notify, channels: Iterable[str]
     ) -> None:
         # We need to acquire a dedicated connection, and use the listen
         # query
@@ -304,14 +304,14 @@ class AiopgConnector(connector.BaseAsyncConnector):
                             query=sql.queries["listen_queue"], channel_name=channel_name
                         ),
                     )
-                # Initial set() lets caller know that we're ready to listen
-                event.set()
-                await self._loop_notify(event=event, connection=connection)
+                await self._loop_notify(
+                    on_notification=on_notification, connection=connection
+                )
 
     @wrap_exceptions()
     async def _loop_notify(
         self,
-        event: asyncio.Event,
+        on_notification: connector.Notify,
         connection: aiopg.Connection,
         timeout: float = connector.LISTEN_TIMEOUT,
     ) -> None:
@@ -324,12 +324,15 @@ class AiopgConnector(connector.BaseAsyncConnector):
             if connection.closed:
                 return
             try:
-                await asyncio.wait_for(connection.notifies.get(), timeout)
+                notification = await asyncio.wait_for(
+                    connection.notifies.get(), timeout
+                )
+                await on_notification(
+                    channel=notification.channel, payload=notification.payload
+                )
             except asyncio.TimeoutError:
                 continue
             except psycopg2.Error:
                 # aiopg>=1.3.1 will raise if the connection is closed while
                 # we wait
                 continue
-
-            event.set()

--- a/procrastinate/contrib/django/django_connector.py
+++ b/procrastinate/contrib/django/django_connector.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import contextlib
 from typing import (
     TYPE_CHECKING,
@@ -141,7 +140,7 @@ class DjangoConnector(connector.BaseAsyncConnector):
             return list(self._dictfetch(cursor))
 
     async def listen_notify(
-        self, event: asyncio.Event, channels: Iterable[str]
+        self, on_notification: connector.Notify, channels: Iterable[str]
     ) -> None:
         raise NotImplementedError(
             "listen/notify is not supported with Django connector"

--- a/procrastinate/contrib/django/migrations/0032_cancel_notification.py
+++ b/procrastinate/contrib/django/migrations/0032_cancel_notification.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+from .. import migrations_utils
+
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations_utils.RunProcrastinateSQL(
+            name="03.00.00_01_cancel_notification.sql"
+        ),
+    ]
+    name = "0032_cancel_notification"
+    dependencies = [("procrastinate", "0031_add_abort_on_procrastinate_jobs")]

--- a/procrastinate/contrib/django/models.py
+++ b/procrastinate/contrib/django/models.py
@@ -99,6 +99,7 @@ class ProcrastinateJob(ProcrastinateReadOnlyModelMixin, models.Model):
             status=self.status,
             scheduled_at=self.scheduled_at,
             attempts=self.attempts,
+            abort_requested=self.abort_requested,
             queueing_lock=self.queueing_lock,
         )
 

--- a/procrastinate/job_context.py
+++ b/procrastinate/job_context.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 import attr
 
@@ -54,6 +54,8 @@ class JobContext:
     additional_context: dict = attr.ib(factory=dict)
     task_result: Any = None
 
+    should_abort: Callable[[], bool]
+
     def evolve(self, **update: Any) -> JobContext:
         return attr.evolve(self, **update)
 
@@ -68,13 +70,3 @@ class JobContext:
             message += f" (started {duration:.3f} s ago)"
 
         return message
-
-    def should_abort(self) -> bool:
-        assert self.job.id
-        job_id = self.job.id
-        return self.app.job_manager.get_job_abort_requested(job_id)
-
-    async def should_abort_async(self) -> bool:
-        assert self.job.id
-        job_id = self.job.id
-        return await self.app.job_manager.get_job_abort_requested_async(job_id)

--- a/procrastinate/psycopg_connector.py
+++ b/procrastinate/psycopg_connector.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
 from typing import (
@@ -249,7 +248,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
 
     @wrap_exceptions()
     async def listen_notify(
-        self, event: asyncio.Event, channels: Iterable[str]
+        self, on_notification: connector.Notify, channels: Iterable[str]
     ) -> None:
         while True:
             async with self._get_standalone_connection() as connection:
@@ -260,14 +259,14 @@ class PsycopgConnector(connector.BaseAsyncConnector):
                             channel_name=channel_name,
                         ),
                     )
-                # Initial set() lets caller know that we're ready to listen
-                event.set()
-                await self._loop_notify(event=event, connection=connection)
+                await self._loop_notify(
+                    on_notification=on_notification, connection=connection
+                )
 
     @wrap_exceptions()
     async def _loop_notify(
         self,
-        event: asyncio.Event,
+        on_notification: connector.Notify,
         connection: psycopg.AsyncConnection,
         timeout: float = connector.LISTEN_TIMEOUT,
     ) -> None:
@@ -275,12 +274,14 @@ class PsycopgConnector(connector.BaseAsyncConnector):
 
         while True:
             try:
-                async for _ in utils.gen_with_timeout(
+                async for notification in utils.gen_with_timeout(
                     aiterable=connection.notifies(),
                     timeout=timeout,
                     raise_timeout=False,
                 ):
-                    event.set()
+                    await on_notification(
+                        channel=notification.channel, payload=notification.payload
+                    )
 
                 await connection.execute("SELECT 1")
             except psycopg.OperationalError:

--- a/procrastinate/sql/migrations/03.00.00_01_cancel_notification.sql
+++ b/procrastinate/sql/migrations/03.00.00_01_cancel_notification.sql
@@ -1,0 +1,87 @@
+CREATE OR REPLACE FUNCTION procrastinate_notify_queue_job_inserted()
+RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    payload TEXT;
+BEGIN
+    SELECT json_object('type': 'job_inserted', 'job_id': NEW.id)::text INTO payload;
+	PERFORM pg_notify('procrastinate_queue#' || NEW.queue_name, payload);
+	PERFORM pg_notify('procrastinate_any_queue', payload);
+	RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS procrastinate_jobs_notify_queue ON procrastinate_jobs;
+
+CREATE TRIGGER procrastinate_jobs_notify_queue_job_inserted
+    AFTER INSERT ON procrastinate_jobs
+    FOR EACH ROW WHEN ((new.status = 'todo'::procrastinate_job_status))
+    EXECUTE PROCEDURE procrastinate_notify_queue_job_inserted();
+
+DROP FUNCTION IF EXISTS procrastinate_notify_queue;
+
+CREATE OR REPLACE FUNCTION procrastinate_notify_queue_abort_job()
+RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    payload TEXT;
+BEGIN
+    SELECT json_object('type': 'abort_job_requested', 'job_id': NEW.id)::text INTO payload;
+	PERFORM pg_notify('procrastinate_queue#' || NEW.queue_name, payload);
+	PERFORM pg_notify('procrastinate_any_queue', payload);
+	RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER procrastinate_jobs_notify_queue_abort_job
+    AFTER UPDATE OF abort_requested ON procrastinate_jobs
+    FOR EACH ROW WHEN ((old.abort_requested = false AND new.abort_requested = true AND new.status = 'doing'::procrastinate_job_status))
+    EXECUTE PROCEDURE procrastinate_notify_queue_abort_job();
+
+CREATE OR REPLACE FUNCTION procrastinate_retry_job(
+    job_id bigint,
+    retry_at timestamp with time zone,
+    new_priority integer,
+    new_queue_name character varying,
+    new_lock character varying
+)
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    _job_id bigint;
+BEGIN
+    UPDATE procrastinate_jobs
+    SET status = CASE
+            WHEN NOT abort_requested THEN 'todo'::procrastinate_job_status
+            ELSE 'failed'::procrastinate_job_status
+        END,
+        attempts = CASE
+            WHEN NOT abort_requested THEN attempts + 1
+            ELSE attempts
+        END,
+        scheduled_at = CASE
+            WHEN NOT abort_requested THEN retry_at
+            ELSE scheduled_at
+        END,
+        priority = CASE
+            WHEN NOT abort_requested THEN COALESCE(new_priority, priority)
+            ELSE priority
+        END,
+        queue_name = CASE
+            WHEN NOT abort_requested THEN COALESCE(new_queue_name, queue_name)
+            ELSE queue_name
+        END,
+        lock = CASE
+            WHEN NOT abort_requested THEN COALESCE(new_lock, lock)
+            ELSE lock
+        END
+    WHERE id = job_id AND status = 'doing'
+    RETURNING id INTO _job_id;
+    IF _job_id IS NULL THEN
+        RAISE 'Job was not found or not in "doing" status (job id: %)', job_id;
+    END IF;
+END;
+$$;

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import asyncio
 import datetime
+import json
 from collections import Counter
 from itertools import count
 from typing import Any, Dict, Iterable
 
-from procrastinate import connector, exceptions, schema, sql, types, utils
+from procrastinate import connector, exceptions, jobs, schema, sql, types, utils
 
 JobRow = Dict[str, Any]
 EventRow = Dict[str, Any]
@@ -37,7 +37,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         self.events: dict[int, list[EventRow]] = {}
         self.job_counter = count(1)
         self.queries: list[tuple[str, dict[str, Any]]] = []
-        self.notify_event: asyncio.Event | None = None
+        self.on_notification: connector.Notify | None = None
         self.notify_channels: list[str] = []
         self.periodic_defers: dict[tuple[str, str], int] = {}
         self.table_exists = True
@@ -73,9 +73,9 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         return await self.generic_execute(query, "all", **arguments)
 
     async def listen_notify(
-        self, event: asyncio.Event, channels: Iterable[str]
+        self, on_notification: connector.Notify, channels: Iterable[str]
     ) -> None:
-        self.notify_event = event
+        self.on_notification = on_notification
         self.notify_channels = list(channels)
 
     def open(self, pool: connector.Pool | None = None) -> None:
@@ -131,11 +131,14 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         if scheduled_at:
             self.events[id].append({"type": "scheduled", "at": scheduled_at})
         self.events[id].append({"type": "deferred", "at": utils.utcnow()})
-        if self.notify_event:
-            if "procrastinate_any_queue" in self.notify_channels or (
-                f"procrastinate_queue#{queue}" in self.notify_channels
-            ):
-                self.notify_event.set()
+
+        await self._notify(
+            queue,
+            {
+                "type": "job_inserted",
+                "job_id": id,
+            },
+        )
         return job_row
 
     async def defer_periodic_job_one(
@@ -177,6 +180,21 @@ class InMemoryConnector(connector.BaseAsyncConnector):
             for job in self.jobs.values()
             if job["status"] in {"failed", "succeeded"}
         ]
+
+    async def _notify(self, queue_name: str, notification: jobs.Notification):
+        if not self.on_notification:
+            return
+
+        destination_channels = {
+            "procrastinate_any_queue",
+            f"procrastinate_queue#{queue_name}",
+        }
+
+        for channel in set(self.notify_channels).intersection(destination_channels):
+            await self.on_notification(
+                channel=channel,
+                payload=json.dumps(notification),
+            )
 
     async def fetch_job_one(self, queues: Iterable[str] | None) -> dict:
         # Creating a copy of the iterable so that we can modify it while we iterate
@@ -226,15 +244,20 @@ class InMemoryConnector(connector.BaseAsyncConnector):
 
         if abort:
             job_row["abort_requested"] = True
+            await self._notify(
+                job_row["queue_name"],
+                {
+                    "type": "abort_job_requested",
+                    "job_id": job_id,
+                },
+            )
+
             return {"id": job_id}
 
         return {"id": None}
 
     async def get_job_status_one(self, job_id: int) -> dict:
         return {"status": self.jobs[job_id]["status"]}
-
-    async def get_job_abort_requested_one(self, job_id: int) -> dict:
-        return {"abort_requested": self.jobs[job_id]["abort_requested"]}
 
     async def retry_job_run(
         self,
@@ -327,6 +350,13 @@ class InMemoryConnector(connector.BaseAsyncConnector):
             stats = Counter(job["status"] for job in lock_jobs)
             result.append({"name": lock, "jobs_count": len(lock_jobs), "stats": stats})
         return result
+
+    async def list_jobs_to_abort_all(self, queue_name: str | None):
+        return list(
+            await self.list_jobs_all(
+                status="doing", abort_requested=True, queue_name=queue_name
+            )
+        )
 
     async def set_job_status_run(self, id, status):
         id = int(id)

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -229,7 +229,7 @@ async def cancel_and_capture_errors(tasks: list[asyncio.Task]):
         if error:
             log_task_exception(task, error=error)
         else:
-            logger.debug(f"Cancelled task ${task.get_name()}")
+            logger.debug(f"Cancelled task {task.get_name()}")
 
 
 async def wait_any(*coros_or_futures: Coroutine | asyncio.Future):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,9 @@ def not_opened_sync_psycopg_connector(psycopg_connection_params):
 
 
 @pytest.fixture
-async def psycopg_connector(not_opened_psycopg_connector):
+async def psycopg_connector(
+    not_opened_psycopg_connector: async_psycopg_connector_module.PsycopgConnector,
+):
     await not_opened_psycopg_connector.open_async()
     yield not_opened_psycopg_connector
     await not_opened_psycopg_connector.close_async()

--- a/tests/integration/contrib/aiopg/conftest.py
+++ b/tests/integration/contrib/aiopg/conftest.py
@@ -27,5 +27,5 @@ async def aiopg_connector_factory(connection_params):
 
 
 @pytest.fixture
-async def aiopg_connector(aiopg_connector_factory):
+async def aiopg_connector(aiopg_connector_factory) -> aiopg.AiopgConnector:
     return await aiopg_connector_factory()

--- a/tests/integration/contrib/django/test_models.py
+++ b/tests/integration/contrib/django/test_models.py
@@ -44,6 +44,7 @@ def test_procrastinate_job__property(db):
         scheduled_at=datetime.datetime(2021, 1, 1, tzinfo=datetime.timezone.utc),
         attempts=0,
         queueing_lock="baz",
+        abort_requested=False,
     )
     assert job.procrastinate_job == jobs_module.Job(
         id=1,

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -96,6 +96,7 @@ async def test_app_run_worker_async_cancel(app: app_module.App):
         result.append(a)
 
     task = asyncio.create_task(app.run_worker_async())
+    await asyncio.sleep(0.01)
     await my_task.defer_async(a=1)
     await asyncio.sleep(0.01)
     task.cancel()

--- a/tests/unit/test_builtin_tasks.py
+++ b/tests/unit/test_builtin_tasks.py
@@ -10,7 +10,7 @@ from procrastinate.testing import InMemoryConnector
 async def test_remove_old_jobs(app: App, job_factory):
     job = job_factory()
     await builtin_tasks.remove_old_jobs(
-        job_context.JobContext(app=app, job=job),
+        job_context.JobContext(app=app, job=job, should_abort=lambda: False),
         max_hours=2,
         queue="queue_a",
         remove_failed=True,

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -30,7 +30,7 @@ async def test_close_async(connector):
         ["execute_query_async", {"query": ""}],
         ["execute_query_one_async", {"query": ""}],
         ["execute_query_all_async", {"query": ""}],
-        ["listen_notify", {"event": None, "channels": []}],
+        ["listen_notify", {"on_notification": None, "channels": []}],
     ],
 )
 async def test_missing_app_async(method_name, kwargs):

--- a/tests/unit/test_job_context.py
+++ b/tests/unit/test_job_context.py
@@ -47,15 +47,17 @@ def test_job_result_as_dict(job_result, expected, mocker):
 
 def test_evolve(app: App, job_factory):
     job = job_factory()
-    context = job_context.JobContext(app=app, job=job, worker_name="a")
+    context = job_context.JobContext(
+        app=app, job=job, worker_name="a", should_abort=lambda: False
+    )
     assert context.evolve(worker_name="b").worker_name == "b"
 
 
 def test_job_description_job_no_time(app: App, job_factory):
     job = job_factory(task_name="some_task", id=12, task_kwargs={"a": "b"})
-    descr = job_context.JobContext(worker_name="a", job=job, app=app).job_description(
-        current_timestamp=0
-    )
+    descr = job_context.JobContext(
+        worker_name="a", job=job, app=app, should_abort=lambda: False
+    ).job_description(current_timestamp=0)
     assert descr == "worker: some_task[12](a='b')"
 
 
@@ -66,21 +68,6 @@ def test_job_description_job_time(app: App, job_factory):
         job=job,
         app=app,
         job_result=job_context.JobResult(start_timestamp=20.0),
+        should_abort=lambda: False,
     ).job_description(current_timestamp=30.0)
     assert descr == "worker: some_task[12](a='b') (started 10.000 s ago)"
-
-
-async def test_should_abort(app, job_factory):
-    await app.job_manager.defer_job_async(job=job_factory())
-    job = await app.job_manager.fetch_job(queues=None)
-    await app.job_manager.cancel_job_by_id_async(job.id, abort=True)
-    context = job_context.JobContext(app=app, job=job)
-    assert await context.should_abort_async() is True
-
-
-async def test_should_not_abort(app, job_factory):
-    await app.job_manager.defer_job_async(job=job_factory())
-    job = await app.job_manager.fetch_job(queues=None)
-    await app.job_manager.cancel_job_by_id_async(job.id)
-    context = job_context.JobContext(app=app, job=job)
-    assert await context.should_abort_async() is False

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -42,6 +42,7 @@ def test_job_get_context(job_factory, scheduled_at, context_scheduled_at):
         "scheduled_at": context_scheduled_at,
         "attempts": 42,
         "call_string": "mytask[12](a='b')",
+        "abort_requested": False,
     }
 
 

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -300,17 +300,17 @@ async def test_retry_job(job_manager, job_factory, connector):
     ],
 )
 async def test_listen_for_jobs(job_manager, connector, mocker, queues, channels):
-    event = mocker.Mock()
+    on_notification = mocker.Mock()
 
-    await job_manager.listen_for_jobs(queues=queues, event=event)
-    assert connector.notify_event is event
+    await job_manager.listen_for_jobs(queues=queues, on_notification=on_notification)
+    assert connector.on_notification
     assert connector.notify_channels == channels
 
 
 @pytest.fixture
 def configure(app):
     @app.task
-    def foo(timestamp):
+    def foo(timestamp: int):
         pass
 
     return foo.configure

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -417,8 +417,15 @@ async def test_listen_for_jobs_run(connector):
 async def test_defer_no_notify(connector):
     # This test is there to check that if the deferred queue doesn't match the
     # listened queue, the testing connector doesn't notify.
+
     event = asyncio.Event()
-    await connector.listen_notify(event=event, channels="some_other_channel")
+
+    async def on_notification(*, channel: str, payload: str):
+        event.set()
+
+    await connector.listen_notify(
+        on_notification=on_notification, channels="some_other_channel"
+    )
     await connector.defer_job_one(
         task_name="foo",
         priority=0,

--- a/tests/unit/test_worker_sync.py
+++ b/tests/unit/test_worker_sync.py
@@ -2,18 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from procrastinate import exceptions, job_context, worker
+from procrastinate import exceptions, worker
 from procrastinate.app import App
 
 
 @pytest.fixture
 def test_worker(app: App) -> worker.Worker:
     return worker.Worker(app=app, queues=["yay"])
-
-
-@pytest.fixture
-def context(app: App, job_factory):
-    return job_context.JobContext(app=app, job=job_factory())
 
 
 def test_worker_find_task_missing(test_worker):


### PR DESCRIPTION


<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [x] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


## Context

So far, the only use of `LISTEN/NOTIFY` has been to let the worker know that a new job is ready to be processed. 

This extends `listen_notify` to accept different types of notification through using the `payload`:
- *job_inserted*: the existing notification
- *abort_job_requested*: when a running job is requested to be aborted.

Instead of making explicit calls to the database every time a job calls `should_abort`, the worker uses the same mechanism than for detecting new jobs, a combination of Postgres notification and polling.


## Other changes

The edge case of retrying a job to be aborted is handled at the database level instead of the worker.

## Next steps

Once this change lands in v3, it will help with cancellation during the shutdown event and #1084