### PR TITLE
Abort async tasks using asyncio

### DIFF
--- a/docs/howto/advanced/cancellation.md
+++ b/docs/howto/advanced/cancellation.md
@@ -75,7 +75,7 @@ async def my_task():
   await do_something()
 ```
 
-It is possible to prevent the job from aborting by capturing asyncio.CancelledError.
+If you want to have some custom behavior at cancellation time, use a combination of [shielding](https://docs.python.org/3/library/asyncio-task.html#shielding-from-cancellation) and capturing `except asyncio.CancelledError`.
 
 ```python
 @app.task()
@@ -87,5 +87,7 @@ async def my_task():
     except asyncio.CancelledError:
       # capture the error and waits for something important to complete
       await important_task
-      # if the job should be marked as aborted, rethrow. Otherwise continue for job to succeed
+      # raise if the job should be marked as aborted, or swallow CancelledError if the job should be
+      # marked as suceeeded
+      raise
 ```

--- a/docs/howto/advanced/cancellation.md
+++ b/docs/howto/advanced/cancellation.md
@@ -47,7 +47,7 @@ When a job is requested to abort and that job fails, it will not be retried (reg
 
 ## Handle an abortion request inside the task
 
-## Sync tasks
+### Sync tasks
 
 In a sync task, we can check (for example, periodically) if the task should be
 aborted. If we want to respect that abortion request (we don't have to), we raise a
@@ -63,10 +63,9 @@ def my_task(context):
     do_something_expensive()
 ```
 
-# Async tasks
+### Async tasks
 
-For async tasks (coroutines), the async taks will be cancelled via [asyncio cancellation](https://docs.python.org/3/library/asyncio-task.html#task-cancellation) mechasnism.
-As such, the task will be cancelled at the next opportunity.
+For async tasks (coroutines), they are cancelled via the [asyncio cancellation](https://docs.python.org/3/library/asyncio-task.html#task-cancellation) mechasnism.
 
 ```python
 @app.task()
@@ -76,14 +75,14 @@ async def my_task():
   await do_something()
 ```
 
-It is possible to prevent the job from aborting by capturing  asyncio.CancelledError.
+It is possible to prevent the job from aborting by capturing asyncio.CancelledError.
 
 ```python
 @app.task()
 async def my_task():
     try:
-      # shield something_important from being cancelled
       important_task = asyncio.create_task(something_important())
+      # shield something_important from being cancelled
       await asyncio.shield(important_task)
     except asyncio.CancelledError:
       # capture the error and waits for something important to complete

--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -110,12 +110,9 @@ async def test_no_job_to_cancel_found(async_app: app_module.App):
 
 @pytest.mark.parametrize("mode", ["listen", "poll"])
 async def test_abort_async_task(async_app: app_module.App, mode):
-    @async_app.task(queue="default", name="task1", pass_context=True)
-    async def task1(context):
-        while True:
-            await asyncio.sleep(0.02)
-            if context.should_abort():
-                raise JobAborted
+    @async_app.task(queue="default", name="task1")
+    async def task1():
+        await asyncio.sleep(0.5)
 
     job_id = await task1.defer_async()
 


### PR DESCRIPTION
Closes #1084

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

## Changes

This modifies the way jobs are being aborted when the task is async, by cancelling the underlying asyncio Task that represents the running job.
