### PR TITLE
Make docs dependencies non optional again

### DIFF
--- a/dev-env
+++ b/dev-env
@@ -61,6 +61,6 @@ echo "We've gone ahead and set up a few additional commands for you:"
 echo "- htmlcov: Opens the test coverage results in your browser"
 echo "- htmldoc: Opens the locally built sphinx documentation in your browser"
 echo "- lint: Run code formatters & linters"
-echo "- docs: Build doc (note: needs 'poetry install --with docs' which needs a recent Python)"
+echo "- docs: Build doc"
 echo ""
 echo 'Quit the poetry shell with the command `deactivate`'

--- a/poetry.lock
+++ b/poetry.lock
@@ -1887,4 +1887,4 @@ sqlalchemy = ["sqlalchemy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c28b113dc79183263b4b933fc30f54de06c861bbf3f5c3128b6de5b06cab4bfd"
+content-hash = "e88d066984b0c6d684aa21f007b9eee8cb3c0fa48eb7f55d4a39b5598822e648"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,11 +92,7 @@ migra = "*"
 # (pkg_resources).
 setuptools = { version = "*" }
 
-[tool.poetry.group.docs]
-optional = true
-
 [tool.poetry.group.docs.dependencies]
-
 django = ">=2.2"
 furo = "*"
 Sphinx = "*"


### PR DESCRIPTION
Make docs dependencies non optional again

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [x] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
