### PR TITLE
Simplify job context

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -32,7 +32,7 @@ When tasks are created with argument ``pass_context``, they are provided a
 `JobContext` argument:
 
 .. autoclass:: procrastinate.JobContext
-    :members: app, worker_name, worker_queues, job, task
+    :members: app, worker_name, worker_queues, job
 
 Blueprints
 ----------

--- a/procrastinate/job_context.py
+++ b/procrastinate/job_context.py
@@ -6,29 +6,27 @@ from typing import Any, Callable, Iterable
 import attr
 
 from procrastinate import app as app_module
-from procrastinate import jobs, tasks, utils
+from procrastinate import jobs, utils
 
 
 @attr.dataclass(kw_only=True)
 class JobResult:
-    start_timestamp: float | None = None
+    start_timestamp: float
     end_timestamp: float | None = None
     result: Any = None
 
     def duration(self, current_timestamp: float) -> float | None:
-        if self.start_timestamp is None:
-            return None
         return (self.end_timestamp or current_timestamp) - self.start_timestamp
 
     def as_dict(self):
         result = {}
-        if self.start_timestamp:
-            result.update(
-                {
-                    "start_timestamp": self.start_timestamp,
-                    "duration": self.duration(current_timestamp=time.time()),
-                }
-            )
+        result.update(
+            {
+                "start_timestamp": self.start_timestamp,
+                "duration": self.duration(current_timestamp=time.time()),
+            }
+        )
+
         if self.end_timestamp:
             result.update({"end_timestamp": self.end_timestamp, "result": self.result})
         return result
@@ -48,11 +46,10 @@ class JobContext:
     worker_queues: Iterable[str] | None = None
     #: Corresponding :py:class:`~jobs.Job`
     job: jobs.Job
-    #: Corresponding :py:class:`~tasks.Task`
-    task: tasks.Task | None = None
-    job_result: JobResult = attr.ib(factory=JobResult)
+    #: Time the job started to be processed
+    start_timestamp: float
+
     additional_context: dict = attr.ib(factory=dict)
-    task_result: Any = None
 
     should_abort: Callable[[], bool]
 
@@ -62,11 +59,3 @@ class JobContext:
     @property
     def queues_display(self) -> str:
         return utils.queues_display(self.worker_queues)
-
-    def job_description(self, current_timestamp: float) -> str:
-        message = f"worker: {self.job.call_string}"
-        duration = self.job_result.duration(current_timestamp)
-        if duration is not None:
-            message += f" (started {duration:.3f} s ago)"
-
-        return message

--- a/tests/unit/test_builtin_tasks.py
+++ b/tests/unit/test_builtin_tasks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import cast
 
 from procrastinate import builtin_tasks, job_context
@@ -10,7 +11,9 @@ from procrastinate.testing import InMemoryConnector
 async def test_remove_old_jobs(app: App, job_factory):
     job = job_factory()
     await builtin_tasks.remove_old_jobs(
-        job_context.JobContext(app=app, job=job, should_abort=lambda: False),
+        job_context.JobContext(
+            app=app, job=job, should_abort=lambda: False, start_timestamp=time.time()
+        ),
         max_hours=2,
         queue="queue_a",
         remove_failed=True,

--- a/tests/unit/test_job_context.py
+++ b/tests/unit/test_job_context.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from procrastinate import job_context
@@ -9,7 +11,6 @@ from procrastinate.app import App
 @pytest.mark.parametrize(
     "job_result, expected",
     [
-        (job_context.JobResult(), None),
         (job_context.JobResult(start_timestamp=10), 20),
         (job_context.JobResult(start_timestamp=10, end_timestamp=15), 5),
     ],
@@ -21,7 +22,6 @@ def test_job_result_duration(job_result, expected):
 @pytest.mark.parametrize(
     "job_result, expected",
     [
-        (job_context.JobResult(), {}),
         (
             job_context.JobResult(start_timestamp=10),
             {
@@ -48,26 +48,10 @@ def test_job_result_as_dict(job_result, expected, mocker):
 def test_evolve(app: App, job_factory):
     job = job_factory()
     context = job_context.JobContext(
-        app=app, job=job, worker_name="a", should_abort=lambda: False
+        start_timestamp=time.time(),
+        app=app,
+        job=job,
+        worker_name="a",
+        should_abort=lambda: False,
     )
     assert context.evolve(worker_name="b").worker_name == "b"
-
-
-def test_job_description_job_no_time(app: App, job_factory):
-    job = job_factory(task_name="some_task", id=12, task_kwargs={"a": "b"})
-    descr = job_context.JobContext(
-        worker_name="a", job=job, app=app, should_abort=lambda: False
-    ).job_description(current_timestamp=0)
-    assert descr == "worker: some_task[12](a='b')"
-
-
-def test_job_description_job_time(app: App, job_factory):
-    job = job_factory(task_name="some_task", id=12, task_kwargs={"a": "b"})
-    descr = job_context.JobContext(
-        worker_name="a",
-        job=job,
-        app=app,
-        job_result=job_context.JobResult(start_timestamp=20.0),
-        should_abort=lambda: False,
-    ).job_description(current_timestamp=30.0)
-    assert descr == "worker: some_task[12](a='b') (started 10.000 s ago)"


### PR DESCRIPTION
Closes #1212

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [x] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

Remove from `JobContext` `job_result`, `task_result` and `task` to keep them internal to the worker.