### PR TITLE
Shutdown timeout - abort sync tasks

### DIFF
--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -30,7 +30,7 @@ class WorkerOptions(TypedDict):
     wait: NotRequired[bool]
     fetch_job_polling_interval: NotRequired[float]
     abort_job_polling_interval: NotRequired[float]
-    shutdown_timeout: NotRequired[float]
+    shutdown_graceful_timeout: NotRequired[float]
     listen_notify: NotRequired[bool]
     delete_jobs: NotRequired[str | jobs.DeleteJobCondition]
     additional_context: NotRequired[dict[str, Any]]
@@ -289,10 +289,11 @@ class App(blueprints.Blueprint):
             mechanism and can reasonably be set to a higher value.
 
             (defaults to 5.0)
-        shutdown_timeout: ``float``
+        shutdown_graceful_timeout: ``float``
             Indicates the maximum duration (in seconds) the worker waits for jobs to
-            complete when requested stop. Jobs that have not been completed by that time
+            complete when requested to stop. Jobs that have not been completed by that time
             are aborted. A value of None corresponds to no timeout.
+
             (defaults to None)
         listen_notify : ``bool``
             If ``True``, allocates a connection from the pool to

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -307,6 +307,13 @@ def configure_worker_parser(subparsers: argparse._SubParsersAction):
     )
     add_argument(
         worker_parser,
+        "--shutdown-graceful-timeout",
+        type=float,
+        help="How long to wait for jobs to complete when shutting down before aborting them",
+        envvar="WORKER_SHUTDOWN_GRACEFUL_TIMEOUT",
+    )
+    add_argument(
+        worker_parser,
         "-w",
         "--wait",
         "--one-shot",

--- a/procrastinate/job_context.py
+++ b/procrastinate/job_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from enum import Enum
 from typing import Any, Callable, Iterable
 
 import attr
@@ -32,6 +33,17 @@ class JobResult:
         return result
 
 
+class AbortReason(Enum):
+    """
+    An enumeration of reasons a job is being aborted
+    """
+
+    USER_REQUEST = "user_request"  #: The user requested to abort the job
+    SHUTDOWN = (
+        "shutdown"  #: The job is being aborted as part of shutting down the worker
+    )
+
+
 @attr.dataclass(frozen=True, kw_only=True)
 class JobContext:
     """
@@ -51,7 +63,10 @@ class JobContext:
 
     additional_context: dict = attr.ib(factory=dict)
 
-    should_abort: Callable[[], bool]
+    abort_reason: Callable[[], AbortReason | None]
+
+    def should_abort(self) -> bool:
+        return bool(self.abort_reason())
 
     def evolve(self, **update: Any) -> JobContext:
         return attr.evolve(self, **update)

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -570,7 +570,7 @@ class JobManager:
         status: str | None = None,
         lock: str | None = None,
         queueing_lock: str | None = None,
-    ) -> Iterable[jobs.Job]:
+    ) -> list[jobs.Job]:
         """
         Sync version of `list_jobs_async`
         """

--- a/tests/acceptance/test_sync.py
+++ b/tests/acceptance/test_sync.py
@@ -33,7 +33,7 @@ async def async_app(not_opened_psycopg_connector):
 
 # Even if we test the purely sync parts, we'll still need an async worker to execute
 # the tasks
-async def test_defer(sync_app, async_app):
+async def test_defer(sync_app: procrastinate.App, async_app: procrastinate.App):
     sum_results = []
     product_results = []
 
@@ -58,7 +58,9 @@ async def test_defer(sync_app, async_app):
     assert product_results == [12]
 
 
-async def test_nested_sync_to_async(sync_app, async_app):
+async def test_nested_sync_to_async(
+    sync_app: procrastinate.App, async_app: procrastinate.App
+):
     sum_results = []
 
     @sync_app.task(queue="default", name="sum_task")
@@ -81,7 +83,9 @@ async def test_nested_sync_to_async(sync_app, async_app):
     assert sum_results == [3]
 
 
-async def test_sync_task_runs_in_parallel(sync_app, async_app):
+async def test_sync_task_runs_in_parallel(
+    sync_app: procrastinate.App, async_app: procrastinate.App
+):
     results = []
 
     @sync_app.task(queue="default", name="sync_task_1")
@@ -105,7 +109,7 @@ async def test_sync_task_runs_in_parallel(sync_app, async_app):
     assert results == [0, 0, 1, 1, 2, 2]
 
 
-async def test_cancel(sync_app, async_app):
+async def test_cancel(sync_app: procrastinate.App, async_app: procrastinate.App):
     sum_results = []
 
     @sync_app.task(queue="default", name="sum_task")
@@ -131,7 +135,7 @@ async def test_cancel(sync_app, async_app):
     assert sum_results == [7]
 
 
-def test_no_job_to_cancel_found(sync_app):
+def test_no_job_to_cancel_found(sync_app: procrastinate.App):
     @sync_app.task(queue="default", name="example_task")
     def example_task():
         pass

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -114,7 +114,7 @@ async def test_app_run_worker_async_abort(app: app_module.App):
         await asyncio.sleep(3)
         result.append(a)
 
-    task = asyncio.create_task(app.run_worker_async(shutdown_timeout=0.1))
+    task = asyncio.create_task(app.run_worker_async(shutdown_graceful_timeout=0.1))
     await my_task.defer_async(a=1)
     await asyncio.sleep(0.01)
     task.cancel()

--- a/tests/unit/test_builtin_tasks.py
+++ b/tests/unit/test_builtin_tasks.py
@@ -12,7 +12,7 @@ async def test_remove_old_jobs(app: App, job_factory):
     job = job_factory()
     await builtin_tasks.remove_old_jobs(
         job_context.JobContext(
-            app=app, job=job, should_abort=lambda: False, start_timestamp=time.time()
+            app=app, job=job, abort_reason=lambda: None, start_timestamp=time.time()
         ),
         max_hours=2,
         queue="queue_a",

--- a/tests/unit/test_job_context.py
+++ b/tests/unit/test_job_context.py
@@ -52,6 +52,6 @@ def test_evolve(app: App, job_factory):
         app=app,
         job=job,
         worker_name="a",
-        should_abort=lambda: False,
+        abort_reason=lambda: None,
     )
     assert context.evolve(worker_name="b").worker_name == "b"

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -291,7 +291,7 @@ async def test_stopping_worker_waits_for_task(app: App, worker):
 @pytest.mark.parametrize("mode", [("stop"), ("cancel")])
 async def test_stopping_worker_aborts_job_after_timeout(app: App, worker, mode):
     complete_task_event = asyncio.Event()
-    worker.shutdown_timeout = 0.02
+    worker.shutdown_graceful_timeout = 0.02
 
     task_cancelled = False
 
@@ -336,7 +336,7 @@ async def test_stopping_worker_aborts_job_after_timeout(app: App, worker, mode):
 
 async def test_stopping_worker_job_suppresses_cancellation(app: App, worker):
     complete_task_event = asyncio.Event()
-    worker.shutdown_timeout = 0.02
+    worker.shutdown_graceful_timeout = 0.02
 
     @app.task()
     async def task_func():
@@ -625,7 +625,7 @@ async def test_run_job_abort(app: App, worker: Worker):
     status = await app.job_manager.get_job_status_async(job_id)
     assert status == Status.ABORTED
     assert (
-        worker._job_ids_to_abort == set()
+        worker._job_ids_to_abort == {}
     ), "Expected cancelled job id to be removed from set"
 
 


### PR DESCRIPTION
Closes #1185

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

This adds support for aborting both sync and async tasks when a worker shuts down and jobs exceed the specified timeout.

Prior to this change, only async tasks were aborted.

`shutdown_timeout `is renamed to `shutdown_graceful_timeout` for clarity.