### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
           - croniter==3.0.3
           - django-stubs==5.1.0
           - django==5.1.1
-          - importlib-resources==6.4.5
           - psycopg2-binary==2.9.9
           - psycopg[pool]==3.2.2
           - python-dateutil==2.9.0.post0

--- a/poetry.lock
+++ b/poetry.lock
@@ -109,39 +109,8 @@ files = [
     {file = "babel-2.16.0.tar.gz", hash = "sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316"},
 ]
 
-[package.dependencies]
-pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
-
 [package.extras]
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
-
-[[package]]
-name = "backports-zoneinfo"
-version = "0.2.1"
-description = "Backport of the standard library zoneinfo module"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
-    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
-    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
-    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
-    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
-]
-
-[package.extras]
-tzdata = ["tzdata"]
 
 [[package]]
 name = "beautifulsoup4"
@@ -411,7 +380,6 @@ files = [
 
 [package.dependencies]
 asgiref = ">=3.6.0,<4"
-"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
 sqlparse = ">=0.3.1"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
@@ -666,28 +634,6 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linke
 enabler = ["pytest-enabler (>=2.2)"]
 perf = ["ipython"]
 test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
-
-[[package]]
-name = "importlib-resources"
-version = "6.4.5"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-6.4.5-py3-none-any.whl", hash = "sha256:ac29d5f956f01d5e4bb63102a5a19957f1b9175e45649977264a1416783bb717"},
-    {file = "importlib_resources-6.4.5.tar.gz", hash = "sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
 type = ["pytest-mypy"]
 
 [[package]]
@@ -982,7 +928,6 @@ files = [
 ]
 
 [package.dependencies]
-"backports.zoneinfo" = {version = ">=0.2.0", markers = "python_version < \"3.9\""}
 psycopg-binary = {version = "3.2.2", optional = true, markers = "implementation_name != \"pypy\" and extra == \"binary\""}
 psycopg-pool = {version = "*", optional = true, markers = "extra == \"pool\""}
 typing-extensions = {version = ">=4.6", markers = "python_version < \"3.13\""}
@@ -1897,5 +1842,5 @@ sqlalchemy = ["sqlalchemy"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "1b96e2c5ab73a198d5ec1f410cbd3f27d0fd28c5e3a7caac32c6567e76efb048"
+python-versions = "^3.9"
+content-hash = "8d4350e830593b495e8caa03a3be60037cdcd221d240b26adf75199a2eb02ff1"

--- a/procrastinate/contrib/django/migrations_utils.py
+++ b/procrastinate/contrib/django/migrations_utils.py
@@ -1,19 +1,9 @@
 from __future__ import annotations
 
 import functools
-import sys
-from typing import TYPE_CHECKING
+from importlib import resources
 
 from django.db import migrations
-
-if TYPE_CHECKING:
-    import importlib_resources
-else:
-    # https://github.com/pypa/twine/pull/551
-    if sys.version_info[:2] < (3, 9):  # coverage: exclude
-        import importlib_resources
-    else:  # coverage: exclude
-        import importlib.resources as importlib_resources
 
 
 @functools.lru_cache(maxsize=None)
@@ -23,7 +13,7 @@ def list_migration_files() -> dict[str, str]:
     """
     return {
         p.name: p.read_text(encoding="utf-8")
-        for p in importlib_resources.files("procrastinate.sql.migrations").iterdir()
+        for p in resources.files("procrastinate.sql.migrations").iterdir()
         if p.name.endswith(".sql")
     }
 

--- a/procrastinate/schema.py
+++ b/procrastinate/schema.py
@@ -1,19 +1,10 @@
 from __future__ import annotations
 
 import pathlib
-import sys
-from typing import TYPE_CHECKING, cast
+from importlib import resources
+from typing import cast
 
 from typing_extensions import LiteralString
-
-if TYPE_CHECKING:
-    import importlib_resources
-else:
-    # https://github.com/pypa/twine/pull/551
-    if sys.version_info[:2] < (3, 9):  # coverage: exclude
-        import importlib_resources
-    else:  # coverage: exclude
-        import importlib.resources as importlib_resources
 
 from procrastinate import connector as connector_module
 
@@ -29,9 +20,9 @@ class SchemaManager:
         # procrastinate takes full responsibility for the queries, we
         # can safely vouch for them being as safe as if they were
         # defined in the code itself.
-        schema_sql = (
-            importlib_resources.files("procrastinate.sql") / "schema.sql"
-        ).read_text(encoding="utf-8")
+        schema_sql = (resources.files("procrastinate.sql") / "schema.sql").read_text(
+            encoding="utf-8"
+        )
         return cast(LiteralString, schema_sql)
 
     @staticmethod

--- a/procrastinate/sql/__init__.py
+++ b/procrastinate/sql/__init__.py
@@ -1,19 +1,10 @@
 from __future__ import annotations
 
 import re
-import sys
-from typing import TYPE_CHECKING, cast
+from importlib import resources
+from typing import cast
 
 from typing_extensions import LiteralString
-
-if TYPE_CHECKING:
-    import importlib_resources
-else:
-    # https://github.com/pypa/twine/pull/551
-    if sys.version_info[:2] < (3, 9):  # coverage: exclude
-        import importlib_resources
-    else:  # coverage: exclude
-        import importlib.resources as importlib_resources
 
 QUERIES_REGEX = re.compile(r"(?:\n|^)-- ([a-z0-9_]+) --\n(?:-- .+\n)*", re.MULTILINE)
 
@@ -37,7 +28,7 @@ def parse_query_file(query_file: str) -> dict[str, LiteralString]:
 
 def get_queries() -> dict[str, LiteralString]:
     return parse_query_file(
-        (importlib_resources.files("procrastinate.sql") / "queries.sql").read_text(
+        (resources.files("procrastinate.sql") / "queries.sql").read_text(
             encoding="utf-8"
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ documentation = "https://procrastinate.readthedocs.io/"
 procrastinate = 'procrastinate.cli:main'
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 aiopg = { version = "*", optional = true }
 anyio = "*"
 asgiref = "*"
@@ -31,12 +31,11 @@ attrs = "*"
 contextlib2 = { version = "*", python = "<3.10" }
 croniter = "*"
 django = { version = ">=2.2", optional = true }
-importlib-resources = { version = ">=1.4", python = "<3.9" }
 psycopg = { extras = ["pool"], version = "*" }
 psycopg2-binary = { version = "*", optional = true }
 python-dateutil = "*"
 sqlalchemy = { version = "^2.0", optional = true }
-typing-extensions = { version = "*", python = "<3.8" }
+typing-extensions = "*"
 sphinx = { version = "*", optional = true }
 
 [tool.poetry.extras]


### PR DESCRIPTION
Drops Python 3.8 support. (Removing asgiref dependency from non-Django code will be done in a separate PR).

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [x] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [x] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
