### PR TITLE
fix fetch job performance regression

### DIFF
--- a/procrastinate/contrib/django/migrations/0031_add_indexes_for_fetch_job.py
+++ b/procrastinate/contrib/django/migrations/0031_add_indexes_for_fetch_job.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+from .. import migrations_utils
+
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations_utils.RunProcrastinateSQL(
+            name="02.14.01_01_add_indexes_for_fetch_job.sql"
+        )
+    ]
+    name = "0031_add_indexes_for_fetch_job"
+    dependencies = [("procrastinate", "0030_alter_procrastinateevent_options")]

--- a/procrastinate/sql/migrations/02.14.01_01_add_indexes_for_fetch_job.sql
+++ b/procrastinate/sql/migrations/02.14.01_01_add_indexes_for_fetch_job.sql
@@ -1,0 +1,7 @@
+-- recreate procrastinate_jobs_id_lock_idx index by adding aborting status to the filter so that it can be used by the fetch job function
+CREATE INDEX procrastinate_jobs_id_lock_idx_temp ON procrastinate_jobs (id, lock) WHERE status = ANY (ARRAY['todo'::procrastinate_job_status, 'doing'::procrastinate_job_status, 'aborting'::procrastinate_job_status]);
+DROP INDEX procrastinate_jobs_id_lock_idx;
+ALTER INDEX procrastinate_jobs_id_lock_idx_temp RENAME TO procrastinate_jobs_id_lock_idx;
+
+-- add index to avoid seq scan of outer query in the fetch job function
+CREATE INDEX procrastinate_jobs_priority_idx ON procrastinate_jobs(priority desc, id asc) WHERE (status = 'todo'::procrastinate_job_status);

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -65,7 +65,9 @@ CREATE UNIQUE INDEX procrastinate_jobs_queueing_lock_idx ON procrastinate_jobs (
 CREATE UNIQUE INDEX procrastinate_jobs_lock_idx ON procrastinate_jobs (lock) WHERE status = 'doing';
 
 CREATE INDEX procrastinate_jobs_queue_name_idx ON procrastinate_jobs(queue_name);
-CREATE INDEX procrastinate_jobs_id_lock_idx ON procrastinate_jobs (id, lock) WHERE status = ANY (ARRAY['todo'::procrastinate_job_status, 'doing'::procrastinate_job_status]);
+CREATE INDEX procrastinate_jobs_id_lock_idx ON procrastinate_jobs (id, lock) WHERE status = ANY (ARRAY['todo'::procrastinate_job_status, 'doing'::procrastinate_job_status, 'aborting'::procrastinate_job_status]);
+CREATE INDEX procrastinate_jobs_priority_idx ON procrastinate_jobs(priority desc, id asc) WHERE (status = 'todo'::procrastinate_job_status);
+
 
 CREATE INDEX procrastinate_events_job_id_fkey ON procrastinate_events(job_id);
 

--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -112,14 +112,14 @@ async def test_abort(async_app):
     @async_app.task(queue="default", name="task1", pass_context=True)
     async def task1(context):
         while True:
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.02)
             if await context.should_abort_async():
                 raise JobAborted
 
     @async_app.task(queue="default", name="task2", pass_context=True)
     def task2(context):
         while True:
-            time.sleep(0.1)
+            time.sleep(0.02)
             if context.should_abort():
                 raise JobAborted
 
@@ -130,11 +130,11 @@ async def test_abort(async_app):
         async_app.run_worker_async(queues=["default"], wait=False)
     )
 
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.05)
     result = await async_app.job_manager.cancel_job_by_id_async(job1_id, abort=True)
     assert result is True
 
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.05)
     result = await async_app.job_manager.cancel_job_by_id_async(job2_id, abort=True)
     assert result is True
 


### PR DESCRIPTION
This modifies indexes to improve performance of the `fetch_job` function.

Recently added features such as job priority and aborting jobs have introduced a performance regression.

It fixes that performance regression by updating an existing index and adding a new one so that the `fetch_job` function avoids sequential scans of the job table in both the outer and inner query.

It also contains an additional timing tweak to an acceptance test to make it less flaky

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
