### PR TITLE
Fix two small typos in Django docs

### DIFF
--- a/docs/howto/django.md
+++ b/docs/howto/django.md
@@ -1,6 +1,6 @@
 # Django integration
 
-While we tries our best for Procrastinate to be easily integrated into diverse
+While we try our best for Procrastinate to be easily integrated into diverse
 kinds of applications, Django is special enough and widely used enough to have a
 special integration.
 

--- a/docs/howto/django/basic_usage.md
+++ b/docs/howto/django/basic_usage.md
@@ -33,7 +33,7 @@ Run the worker with the following command.
 
 `./manage.py procrastinate` mostly behaves like the `procrastinate` command
 itself. The subcommand `schema` is not available, as Procrastinate will use
-Django migrations. The `--app` option is also not available, as Procrastinate
+Django migrations. The `--app` option is also not available, as Procrastinate will use
 the automatically provided app (see {doc}`configuration`).
 
 :::{note}


### PR DESCRIPTION
Closes #<ticket number>

### Successful PR Checklist:
- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): 
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [x] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
