### PR TITLE
Constraint to prevent jobs in todo state with abort_requested

### DIFF
--- a/procrastinate/sql/migrations/03.00.00_50_post_cancel_notification.sql
+++ b/procrastinate/sql/migrations/03.00.00_50_post_cancel_notification.sql
@@ -200,3 +200,6 @@ CREATE TRIGGER procrastinate_trigger_abort_requested_events_v1
 -- Rename remaining functions to use version suffix
 ALTER FUNCTION procrastinate_unlink_periodic_defers RENAME TO procrastinate_unlink_periodic_defers_v1;
 ALTER TRIGGER procrastinate_trigger_delete_jobs ON procrastinate_jobs RENAME TO procrastinate_trigger_delete_jobs_v1;
+
+-- New constraints
+ALTER TABLE procrastinate_jobs ADD CONSTRAINT check_not_todo_abort_requested CHECK (NOT (status = 'todo' AND abort_requested = true));

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -39,7 +39,8 @@ CREATE TABLE procrastinate_jobs (
     status procrastinate_job_status DEFAULT 'todo'::procrastinate_job_status NOT NULL,
     scheduled_at timestamp with time zone NULL,
     attempts integer DEFAULT 0 NOT NULL,
-    abort_requested boolean DEFAULT false NOT NULL
+    abort_requested boolean DEFAULT false NOT NULL,
+    CONSTRAINT check_not_todo_abort_requested CHECK (NOT (status = 'todo' AND abort_requested = true))
 );
 
 CREATE TABLE procrastinate_periodic_defers (


### PR DESCRIPTION
Closes #1182

I don't think there is a direct way to test this via the Python API.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
