### PR TITLE
Add task back as a property on job context

### DIFF
--- a/docs/howto/advanced/retry.md
+++ b/docs/howto/advanced/retry.md
@@ -9,36 +9,36 @@ app / machine reboots.
 
 ## Simple strategies
 
-- Retry 5 times (so 6 attempts total):
+-   Retry 5 times (so 6 attempts total):
 
-  ```python
-  @app.task(retry=5)
-  def flaky_task():
-      if random.random() > 0.9:
-          raise Exception("Who could have seen this coming?")
-      print("Hello world")
-  ```
+    ```python
+    @app.task(retry=5)
+    def flaky_task():
+        if random.random() > 0.9:
+            raise Exception("Who could have seen this coming?")
+        print("Hello world")
+    ```
 
-- Retry indefinitely:
+-   Retry indefinitely:
 
-  ```python
-  @app.task(retry=True)
-  def flaky_task():
-      if random.random() > 0.9:
-          raise Exception("Who could have seen this coming?")
-      print("Hello world")
-  ```
+    ```python
+    @app.task(retry=True)
+    def flaky_task():
+        if random.random() > 0.9:
+            raise Exception("Who could have seen this coming?")
+        print("Hello world")
+    ```
 
 ## Advanced strategies
 
 Advanced strategies let you:
 
-- define a maximum number of retries (if you don't, jobs will be retried indefinitely
-  until they pass)
-- define the retry delay, with constant, linear and exponential backoff options (if
-  you don't, jobs will be retried immediately)
-- define the exception types you want to retry on (if you don't, jobs will be retried
-  on any type of exceptions)
+-   define a maximum number of retries (if you don't, jobs will be retried indefinitely
+    until they pass)
+-   define the retry delay, with constant, linear and exponential backoff options (if
+    you don't, jobs will be retried immediately)
+-   define the exception types you want to retry on (if you don't, jobs will be retried
+    on any type of exceptions)
 
 Define your precise strategy using a {py:class}`RetryStrategy` instance:
 
@@ -57,9 +57,9 @@ def my_other_task():
 {py:class}`RetryStrategy` takes 3 parameters related to how long it will wait
 between retries:
 
-- `wait=5` to wait 5 seconds before each retry
-- `linear_wait=5` to wait 5 seconds then 10 then 15 and so on
-- `exponential_wait=5` to wait 5 seconds then 25 then 125 and so on
+-   `wait=5` to wait 5 seconds before each retry
+-   `linear_wait=5` to wait 5 seconds then 10 then 15 and so on
+-   `exponential_wait=5` to wait 5 seconds then 25 then 125 and so on
 
 ## Implementing your own strategy
 
@@ -73,28 +73,45 @@ The time to wait between retries can be specified with `retry_in` or alternative
 with `retry_at`. This is similar to how `schedule_in` and `schedule_at` are used
 when {doc}`scheduling a job in the future <schedule>`.
 
-  ```python
-  import random
-  from procrastinate import Job, RetryDecision
+```python
+import random
+from procrastinate import Job, RetryDecision
 
-  class RandomRetryStrategy(procrastinate.BaseRetryStrategy):
-      max_attempts = 3
-      min = 1
-      max = 10
+class RandomRetryStrategy(procrastinate.BaseRetryStrategy):
+    max_attempts = 3
+    min = 1
+    max = 10
 
-      def get_retry_decision(self, *, exception:Exception, job:Job) -> RetryDecision:
-          if job.attempts >= max_attempts:
-              return RetryDecision(should_retry=False)
+    def get_retry_decision(self, *, exception:Exception, job:Job) -> RetryDecision:
+        if job.attempts >= max_attempts:
+            return RetryDecision(should_retry=False)
 
-          wait = random.uniform(self.min, self.max)
+        wait = random.uniform(self.min, self.max)
 
-          return RetryDecision(
-              retry_in={"seconds": wait}, # or retry_at (a datetime object)
-              priority=job.priority + 1, # optional
-              queue="another_queue", # optional
-              lock="another_lock", # optional
-          )
-  ```
+        return RetryDecision(
+            retry_in={"seconds": wait}, # or retry_at (a datetime object)
+            priority=job.priority + 1, # optional
+            queue="another_queue", # optional
+            lock="another_lock", # optional
+        )
+```
 
 There is also a legacy `get_schedule_in` method that is deprecated an will be
 removed in a future version in favor of the above `get_retry_decision` method.
+
+## Knowing whether a job is on its last attempt
+
+By using `pass_context=True`, and introspecting the task's retry strategy,
+you can know whether a currently executing job is on its last attempt:
+
+```python
+@app.task(retry=10, pass_context=True)
+def my_task(job_context: procrastinate.JobContext) -> None:
+	job = job_context.job
+	task = job_context.task
+    if task.retry.get_retry_decision(exception=Exception(), job=job) is None:
+        print("Warning: last attempt!")
+
+    if random.random() < 0.9:
+        raise Exception
+```

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -32,7 +32,7 @@ When tasks are created with argument ``pass_context``, they are provided a
 `JobContext` argument:
 
 .. autoclass:: procrastinate.JobContext
-    :members: app, worker_name, worker_queues, job
+    :members: app, worker_name, worker_queues, job, task, should_abort
 
 Blueprints
 ----------
@@ -80,7 +80,7 @@ Exceptions
 .. automodule:: procrastinate.exceptions
     :members: ProcrastinateException, LoadFromPathError,
               ConnectorException, AlreadyEnqueued, AppNotOpen, TaskNotFound,
-              UnboundTaskError
+              UnboundTaskError, JobAborted
 
 Job statuses
 ------------

--- a/tests/unit/test_job_context.py
+++ b/tests/unit/test_job_context.py
@@ -55,3 +55,19 @@ def test_evolve(app: App, job_factory):
         abort_reason=lambda: None,
     )
     assert context.evolve(worker_name="b").worker_name == "b"
+
+
+def test_task(app: App, job_factory):
+    @app.task(name="my_task")
+    def my_task(a, b):
+        return a + b
+
+    job = job_factory(task_name="my_task")
+    context = job_context.JobContext(
+        start_timestamp=time.time(),
+        app=app,
+        job=job,
+        worker_name="a",
+        abort_reason=lambda: None,
+    )
+    assert context.task == my_task


### PR DESCRIPTION
Closes #1212

Add the `job_context.task` back, but as a property of already existing attributes.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
