### PR TITLE
Fix acceptance test when releasing

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -77,8 +77,12 @@ def stable_version_without_post_migration(session: nox.Session):
         shutil.copy(base_path / "poetry.lock", temp_path / "poetry.lock")
         session.run("poetry", "install", "--with", "test", "--no-root", external=True)
 
-        # Install latest procrastinate from PyPI
-        session.install("procrastinate")
+        # Install latest procrastinate from GitHub
+        # During a tag release, we have not yet published the new version to PyPI
+        # so we need to install it from GitHub
+        session.install(
+            f"procrastinate @ git+https://github.com/procrastinate-org/procrastinate.git@{latest_tag}"
+        )
 
         session.run(
             "pytest",


### PR DESCRIPTION
Closes #<ticket number>

During the brief moment where we have a new tag and not the new PyPI release yet, it's exactly the moment where the tag build launches the acceptance tests, and so we need to make sure they can run at that moment too

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
