### PR TITLE
uv manages to understand it needs to differentiate the django version depending on python

### DIFF
--- a/docs/howto/django/configuration.md
+++ b/docs/howto/django/configuration.md
@@ -10,12 +10,6 @@ how.
 For each Python version supported by Procrastinate, Procastinate is tested with
 the latest Django version supported by that Python version.
 
-As of January 2025, this means Procrastinate is tested with Django 4.2 for
-Python 3.8 and 3.9, and Django 5.1 for Python 3.10+. This paragraph is likely
-to be outdated in the future, the best way to get up-to-date info is to have a
-look at the `django` dependency group section of the [package
-configuration](https://github.com/procrastinate-org/procrastinate/blob/main/pyproject.toml#L78-81)
-
 ## Installation & configuration
 
 To start, install procrastinate with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,7 @@ pg_implem = [
     "psycopg[binary,pool]; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.10'",
     "psycopg[pool]; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version < '3.10'",
 ]
-django = [
-    "django<6; python_version < '3.10'",
-    "django; python_version >= '3.10'",
-]
+django = ["django"]
 test = [
     "pytest-asyncio",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,14 +59,7 @@ procrastinate = 'procrastinate.cli:main'
 [tool.uv]
 cache-keys = [{ git = { commit = true, tags = true } }]
 required-version = ">=0.5.21"
-default-groups = [
-    "release",
-    "lint_format",
-    "pg_implem",
-    "django",
-    "test",
-    "docs",
-]
+default-groups = ["release", "lint_format", "pg_implem", "test", "docs"]
 
 [dependency-groups]
 types = ["django-stubs"]
@@ -80,7 +73,6 @@ pg_implem = [
     "psycopg[binary,pool]; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version >= '3.10'",
     "psycopg[pool]; sys_platform == 'darwin' and platform_machine == 'arm64' and python_version < '3.10'",
 ]
-django = ["django"]
 test = [
     "pytest-asyncio",
     "pytest-cov",

--- a/scripts/sync-pre-commit.py
+++ b/scripts/sync-pre-commit.py
@@ -66,7 +66,6 @@ def main():
         "--no-group=release",
         "--no-group=lint_format",
         "--no-group=pg_implem",
-        "--no-group=django",
         "--no-group=test",
         "--no-group=docs",
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -824,10 +824,7 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
 ]
-django = [
-    { name = "django", marker = "python_full_version < '3.10'", specifier = "<6" },
-    { name = "django", marker = "python_full_version >= '3.10'" },
-]
+django = [{ name = "django" }]
 docs = [
     { name = "django", specifier = ">=2.2" },
     { name = "furo" },

--- a/uv.lock
+++ b/uv.lock
@@ -759,10 +759,6 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
 ]
-django = [
-    { name = "django", version = "4.2.18", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "django", version = "5.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-]
 docs = [
     { name = "django", version = "4.2.18", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "django", version = "5.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -824,7 +820,6 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
 ]
-django = [{ name = "django" }]
 docs = [
     { name = "django", specifier = ">=2.2" },
     { name = "furo" },


### PR DESCRIPTION
<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
