### PR TITLE
Add some very simple benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+    branches:
+      - "main"
+
+permissions:
+  deployments: write
+  contents: write
+
+env:
+  UV_FROZEN: "true"
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        # Set health checks to wait until postgres has started
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5
+        with:
+          python-version: "3.13"
+
+      - name: Run benchmarks
+        run: uv run pytest -m "benchmark" --benchmark-json output.json
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1
+        with:
+          name: Procrastinate Benchmarks
+          tool: "pytest"
+          output-file-path: output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,38 @@ jobs:
           name: python-coverage-comment-action
           path: python-coverage-comment-action.txt
 
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        # Set health checks to wait until postgres has started
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@f94ec6bedd8674c4426838e6b50417d36b6ab231 # v5
+        with:
+          python-version: "3.13"
+
+      - name: Run benchmarks
+        run: uv run pytest -m "benchmark"
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
   publish:
     name: Publish package to PyPI
     if: github.event_name == 'push' && github.ref_type == 'tag'

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 docs/_build
 htmlcov
 VERSION.txt
+.benchmarks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ pg_implem = [
 ]
 test = [
     "pytest-asyncio",
+    "pytest-benchmark",
     "pytest-cov",
     "pytest-django",
     "pytest-mock",
@@ -99,12 +100,13 @@ docs = [
 dev = ["ruff", "pyright", "doc8"]
 
 [tool.pytest.ini_options]
-addopts = ["-vv", "--strict-markers", "-rfE", "--reuse-db"]
+addopts = ["-vv", "--strict-markers", "-rfE", "--reuse-db", "-m not benchmark"]
 testpaths = [
     "tests/unit",
     "tests/integration",
     "tests/acceptance",
     "tests/migration",
+    "tests/benchmarks",
 ]
 # https://adamj.eu/tech/2025/01/08/django-silence-exception-ignored-outputwrapper/
 # https://code.djangoproject.com/ticket/36056

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture
+def aio_benchmark(benchmark):
+    def _wrapper(func, *args, **kwargs):
+        if asyncio.iscoroutinefunction(func):
+            event_loop = asyncio.get_event_loop()
+
+            @benchmark
+            def _():
+                return event_loop.run_until_complete(func(*args, **kwargs))
+        else:
+            benchmark(func, *args, **kwargs)
+
+    return _wrapper

--- a/tests/benchmarks/test_benchmark_async.py
+++ b/tests/benchmarks/test_benchmark_async.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from procrastinate import app as app_module
+from procrastinate.contrib import aiopg
+
+
+@pytest.fixture(params=["psycopg_connector", "aiopg_connector"])
+async def async_app(request, psycopg_connector, connection_params):
+    app = app_module.App(
+        connector={
+            "psycopg_connector": psycopg_connector,
+            "aiopg_connector": aiopg.AiopgConnector(**connection_params),
+        }[request.param]
+    )
+    async with app.open_async():
+        yield app
+
+
+@pytest.mark.benchmark
+def test_benchmark_1000_async_jobs(aio_benchmark, async_app: app_module.App):
+    @async_app.task(queue="default", name="simple_task")
+    async def simple_task():
+        pass
+
+    async def defer_and_process_jobs():
+        for _ in range(1000):
+            await simple_task.defer_async()
+
+        await async_app.run_worker_async(queues=["default"], wait=False)
+
+    aio_benchmark(defer_and_process_jobs)

--- a/tests/benchmarks/test_benchmark_sync.py
+++ b/tests/benchmarks/test_benchmark_sync.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+import procrastinate
+from procrastinate.contrib import psycopg2
+
+
+@pytest.fixture(params=["sync_psycopg_connector", "psycopg2_connector"])
+async def sync_app(request, sync_psycopg_connector, connection_params):
+    app = procrastinate.App(
+        connector={
+            "sync_psycopg_connector": sync_psycopg_connector,
+            "psycopg2_connector": psycopg2.Psycopg2Connector(**connection_params),
+        }[request.param]
+    )
+
+    with app.open():
+        yield app
+
+
+@pytest.fixture
+async def async_app(not_opened_psycopg_connector):
+    app = procrastinate.App(connector=not_opened_psycopg_connector)
+    async with app.open_async():
+        yield app
+
+
+@pytest.mark.benchmark
+def test_benchmark_1000_sync_jobs(
+    aio_benchmark, sync_app: procrastinate.App, async_app: procrastinate.App
+):
+    @sync_app.task(queue="default", name="sum_task")
+    def simple_task():
+        pass
+
+    async def defer_and_process_jobs():
+        for _ in range(1000):
+            simple_task.defer()
+
+        await async_app.run_worker_async(queues=["default"], wait=False)
+
+    aio_benchmark(defer_and_process_jobs)

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin'",
@@ -787,6 +788,7 @@ release = [
 test = [
     { name = "migra" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "pytest-mock" },
@@ -812,6 +814,7 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = "~=2.0" },
     { name = "typing-extensions" },
 ]
+provides-extras = ["aiopg", "django", "psycopg2", "sphinx", "sqlalchemy"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -842,6 +845,7 @@ release = [{ name = "dunamai" }]
 test = [
     { name = "migra" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "pytest-mock" },
@@ -1011,6 +1015,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1059,6 +1072,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d0/a8bd08d641b393db3be3819b03e2d9bb8760ca8479080a26a5f6e540e99c/pytest-benchmark-5.1.0.tar.gz", hash = "sha256:9ea661cdc292e8231f7cd4c10b0319e56a2118e2c09d9f50e1b3d150d2aca105", size = 337810 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/d6/b41653199ea09d5969d4e385df9bbfd9a100f28ca7e824ce7c0a016e3053/pytest_benchmark-5.1.0-py3-none-any.whl", hash = "sha256:922de2dfa3033c227c96da942d1878191afa135a29485fb942e85dff1c592c89", size = 44259 },
 ]
 
 [[package]]


### PR DESCRIPTION
Some very simple benchmarks using `pytest-benchmark` and `github-action-benchmark`. It can undoubtedly be improved, but at least a starting point.

During CI workflow, benchmarks run and are logged to the console but are not published on Github pages (as we don't want this to happen on PRs). Instead, the benchmark workflow that runs only on push does publish to Github pages (I have not tried this out).

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
