### PR TITLE
Fix (probably) incorrect test matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,8 @@ jobs:
   tests:
     strategy:
       matrix:
-        include:
-          - python-version: "3.9"
-            postgres-version: "13"
-          - python-version: "3.10"
-            postgres-version: "14"
-          - python-version: "3.11"
-            postgres-version: "15"
-          - python-version: "3.12"
-            postgres-version: "16"
-          - python-version: "3.13"
-            postgres-version: "17"
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        postgres-version: ["13", "14", "15", "16", "17"]
 
     name: "py${{ matrix.python-version }}"
     runs-on: ubuntu-latest


### PR DESCRIPTION
The way the test matrix is currently setup doesn't test against all supported combinations of python versions and postgres versions, but rather just in sets of {py3.9, pg13}, {py3.10, pg14}, {py3.11, pg15}, etc, which is most likely not intentional. This change ensure CI/CD tests against the full range.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
