### PR TITLE
Revert "Add missing pytest's marker description"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ asyncio_default_fixture_loop_scope = "function"
 django_find_project = false
 DJANGO_SETTINGS_MODULE = "tests.acceptance.django_settings"
 pythonpath = ["."]
-markers = ["benchmark: Tests dedicated to detect performance regressions"]
 
 [tool.coverage.run]
 relative_files = true


### PR DESCRIPTION
Reverts procrastinate-org/procrastinate#1348

It turns out this marker is provided by pytest-benchmark
```
> pytest --markers
...
@pytest.mark.benchmark: mark a test with custom benchmark settings.
...
```
I have forgotten to sync my dependencies with upstream.