### PR TITLE
Adjust sleep times in test_stop_worker_aborts_sync_jobs_past_shutdown_graceful_timeout

### DIFF
--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -386,7 +386,7 @@ async def test_stop_worker_aborts_sync_jobs_past_shutdown_graceful_timeout(
     def slow_job(context: JobContext):
         nonlocal slow_job_cancelled
         while True:
-            time.sleep(0.05)
+            time.sleep(0.01)
             if context.should_abort():
                 slow_job_cancelled = True
                 raise JobAborted()
@@ -402,6 +402,8 @@ async def test_stop_worker_aborts_sync_jobs_past_shutdown_graceful_timeout(
     with pytest.raises(asyncio.CancelledError):
         run_task.cancel()
         await run_task
+
+    await asyncio.sleep(0.05)
 
     fast_job_status = await async_app.job_manager.get_job_status_async(fast_job_id)
     slow_job_status = await async_app.job_manager.get_job_status_async(slow_job_id)


### PR DESCRIPTION
Closes #<ticket number>

e.g. https://github.com/procrastinate-org/procrastinate/actions/runs/14007820044/job/39223899638?pr=1353 or https://github.com/procrastinate-org/procrastinate/actions/runs/14007667420/job/39223586810

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
