### PR TITLE
String interpolation on queueing_lock

### DIFF
--- a/docs/howto/advanced/queueing_locks.md
+++ b/docs/howto/advanced/queueing_locks.md
@@ -34,6 +34,19 @@ def my_task(**kwargs):
     ...
 ```
 
+Queueing lock can also be interpolated with the parameters sent to the task.
+In this example:
+
+```
+@app.task(queueing_lock="my_lock_value_{param_1}")
+def my_task(param_1="aaa", **kwargs):
+    ...
+
+```
+
+the queing lock value will be `my_lock_value_aaa`. (Under the hood we are invocating the
+method .format(\*\*task_kwargs) of the queueing_lock's value.)
+
 `queueing_lock` allows a single job in `todo` status. Meanwhile, it allows multiple jobs to be in `doing` status.
 
 To enforce that only one job runs at a time while limiting the queue size, you can combine `queueing_lock` with [lock](./locks.md).

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -34,6 +34,12 @@ class TaskAlreadyRegistered(ProcrastinateException):
     """
 
 
+class TaskMisconfigured(ProcrastinateException):
+    """
+    Configuration of the task is unsound.
+    """
+
+
 class LoadFromPathError(ImportError, ProcrastinateException):
     """
     App was not found at the provided path, or the loaded object is not an App.

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -48,11 +48,22 @@ def configure_task(
         priority = jobs.DEFAULT_PRIORITY
 
     task_kwargs = options.get("task_kwargs") or {}
+    if queueing_lock := options.get("queueing_lock"):
+        try:
+            queueing_lock = queueing_lock.format(**task_kwargs)
+        except KeyError as exc:
+            raise exceptions.TaskMisconfigured(
+                message="queueing_lock formatting failed"
+            ) from exc
+
+    else:
+        queueing_lock = None
+
     return jobs.JobDeferrer(
         job=jobs.Job(
             id=None,
             lock=options.get("lock"),
-            queueing_lock=options.get("queueing_lock"),
+            queueing_lock=queueing_lock,
             task_name=name,
             queue=options.get("queue") or jobs.DEFAULT_QUEUE,
             task_kwargs=task_kwargs,

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -4,6 +4,7 @@ import pytest
 
 from procrastinate import tasks, utils
 from procrastinate.app import App
+from procrastinate.exceptions import TaskMisconfigured
 
 from .. import conftest
 
@@ -137,3 +138,18 @@ def test_task_get_retry_exception(app, mocker):
     assert task.get_retry_exception(exception=exception, job=job) is mock.return_value
     mock.assert_called_with(exception=exception, job=job)
     mock.assert_called_with(exception=exception, job=job)
+
+
+def test_task_configure_queueing_lock_interpolation(app):
+    task = tasks.Task(task_func, blueprint=app, queue="queue")
+
+    job = task.configure(queueing_lock="lock_{param}", task_kwargs={"param": "1"}).job
+
+    assert job.queueing_lock == "lock_1"
+
+
+def test_task_configure_queueing_lock_interpolation_failed(app):
+    task = tasks.Task(task_func, blueprint=app, queue="queue")
+
+    with pytest.raises(TaskMisconfigured):
+        task.configure(queueing_lock="lock_{param}", task_kwargs={}).job


### PR DESCRIPTION
Allow the `queueing_lock` to be interpolated with any values from the parameters send to the task.


<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [x] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
