### PR TITLE
fix: try to reconnect on exception

### DIFF
--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -31,6 +31,7 @@ class WorkerOptions(TypedDict):
     abort_job_polling_interval: NotRequired[float]
     shutdown_graceful_timeout: NotRequired[float]
     listen_notify: NotRequired[bool]
+    listen_notify_reconnect_interval: NotRequired[float]
     delete_jobs: NotRequired[str | jobs.DeleteJobCondition]
     additional_context: NotRequired[dict[str, Any]]
     install_signal_handlers: NotRequired[bool]
@@ -305,6 +306,9 @@ class App(blueprints.Blueprint):
             Provides lower latency for job updates compared to polling alone.
 
             Note: Worker polls the database regardless of this setting. (defaults to ``True``)
+        listen_notify_reconnect_interval : ``float``
+            Time in seconds to wait before attempting to reconnect after a connection
+            failure in ``listen_notify``. (defaults to 2.0).
         delete_jobs : ``str``
             If ``always``, the worker will automatically delete all jobs on completion.
             If ``successful`` the worker will only delete successful jobs.

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -338,6 +338,13 @@ def configure_worker_parser(subparsers: argparse._SubParsersAction):
     )
     add_argument(
         worker_parser,
+        "--listen-notify-reconnect-interval",
+        type=float,
+        help="How long to wait before attempting to reconnect after a connection failure in listen_notify",
+        envvar="WORKER_LISTEN_NOTIFY_RECONNECT_INTERVAL",
+    )
+    add_argument(
+        worker_parser,
         "--delete-jobs",
         choices=jobs.DeleteJobCondition,
         type=jobs.DeleteJobCondition,

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -67,7 +67,7 @@ class BaseConnector:
         on_notification: Notify,
         channels: Iterable[str],
         *,
-        listen_notify_reconnect_interval: float = 2.0,
+        reconnect_interval: float = 2.0,
     ) -> None:
         raise exceptions.SyncConnectorConfigurationError
 
@@ -110,6 +110,6 @@ class BaseAsyncConnector(BaseConnector):
         on_notification: Notify,
         channels: Iterable[str],
         *,
-        listen_notify_reconnect_interval: float = 2.0,
+        reconnect_interval: float = 2.0,
     ) -> None:
         raise NotImplementedError

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -66,6 +66,8 @@ class BaseConnector:
         self,
         on_notification: Notify,
         channels: Iterable[str],
+        *,
+        listen_notify_reconnect_interval: float = 2.0,
     ) -> None:
         raise exceptions.SyncConnectorConfigurationError
 
@@ -104,6 +106,6 @@ class BaseAsyncConnector(BaseConnector):
         return utils.async_to_sync(self.execute_query_all_async, query, **arguments)
 
     async def listen_notify(
-        self, on_notification: Notify, channels: Iterable[str]
+        self, on_notification: Notify, channels: Iterable[str], *, listen_notify_reconnect_interval: float = 2.0
     ) -> None:
         raise NotImplementedError

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -106,6 +106,10 @@ class BaseAsyncConnector(BaseConnector):
         return utils.async_to_sync(self.execute_query_all_async, query, **arguments)
 
     async def listen_notify(
-        self, on_notification: Notify, channels: Iterable[str], *, listen_notify_reconnect_interval: float = 2.0
+        self,
+        on_notification: Notify,
+        channels: Iterable[str],
+        *,
+        listen_notify_reconnect_interval: float = 2.0,
     ) -> None:
         raise NotImplementedError

--- a/procrastinate/contrib/aiopg/aiopg_connector.py
+++ b/procrastinate/contrib/aiopg/aiopg_connector.py
@@ -37,7 +37,8 @@ async def wrap_exceptions() -> AsyncGenerator[None, None]:
         queueing_lock = None
         if constraint_name == manager.QUEUEING_LOCK_CONSTRAINT:
             assert exc.diag.message_detail
-            match = re.search(r"Key \((.*?)\)=\((.*?)\)", exc.diag.message_detail)
+            match = re.search(r"Key \((.*?)\)=\((.*?)\)",
+                              exc.diag.message_detail)
             assert match
             column, queueing_lock = match.groups()
             assert column == "queueing_lock"
@@ -180,7 +181,8 @@ class AiopgConnector(connector.BaseAsyncConnector):
             if base_on_connect:
                 await base_on_connect(connection)
             if json_loads:
-                psycopg2.extras.register_default_jsonb(connection.raw, loads=json_loads)
+                psycopg2.extras.register_default_jsonb(
+                    connection.raw, loads=json_loads)
 
         final_args = {
             "dsn": "",
@@ -307,7 +309,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
         on_notification: connector.Notify,
         channels: Iterable[str],
         *,
-        listen_notify_reconnect_interval: float = 2.0,
+        reconnect_interval: float = 2.0,
     ) -> None:
         # We need to acquire a dedicated connection, and use the listen
         # query

--- a/procrastinate/contrib/aiopg/aiopg_connector.py
+++ b/procrastinate/contrib/aiopg/aiopg_connector.py
@@ -326,7 +326,8 @@ class AiopgConnector(connector.BaseAsyncConnector):
                         await self._execute_query_connection(
                             connection=connection,
                             query=self._make_dynamic_query(
-                                query=sql.queries["listen_queue"], channel_name=channel_name
+                                query=sql.queries["listen_queue"],
+                                channel_name=channel_name,
                             ),
                         )
                     await self._loop_notify(

--- a/procrastinate/contrib/aiopg/aiopg_connector.py
+++ b/procrastinate/contrib/aiopg/aiopg_connector.py
@@ -37,8 +37,7 @@ async def wrap_exceptions() -> AsyncGenerator[None, None]:
         queueing_lock = None
         if constraint_name == manager.QUEUEING_LOCK_CONSTRAINT:
             assert exc.diag.message_detail
-            match = re.search(r"Key \((.*?)\)=\((.*?)\)",
-                              exc.diag.message_detail)
+            match = re.search(r"Key \((.*?)\)=\((.*?)\)", exc.diag.message_detail)
             assert match
             column, queueing_lock = match.groups()
             assert column == "queueing_lock"
@@ -181,8 +180,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
             if base_on_connect:
                 await base_on_connect(connection)
             if json_loads:
-                psycopg2.extras.register_default_jsonb(
-                    connection.raw, loads=json_loads)
+                psycopg2.extras.register_default_jsonb(connection.raw, loads=json_loads)
 
         final_args = {
             "dsn": "",

--- a/procrastinate/contrib/aiopg/aiopg_connector.py
+++ b/procrastinate/contrib/aiopg/aiopg_connector.py
@@ -303,7 +303,11 @@ class AiopgConnector(connector.BaseAsyncConnector):
 
     @wrap_exceptions()
     async def listen_notify(
-        self, on_notification: connector.Notify, channels: Iterable[str], *, listen_notify_reconnect_interval: float = 2.0
+        self,
+        on_notification: connector.Notify,
+        channels: Iterable[str],
+        *,
+        listen_notify_reconnect_interval: float = 2.0,
     ) -> None:
         # We need to acquire a dedicated connection, and use the listen
         # query

--- a/procrastinate/contrib/aiopg/aiopg_connector.py
+++ b/procrastinate/contrib/aiopg/aiopg_connector.py
@@ -320,17 +320,22 @@ class AiopgConnector(connector.BaseAsyncConnector):
             return
 
         while True:
-            async with self.pool.acquire() as connection:
-                for channel_name in channels:
-                    await self._execute_query_connection(
-                        connection=connection,
-                        query=self._make_dynamic_query(
-                            query=sql.queries["listen_queue"], channel_name=channel_name
-                        ),
+            try:
+                async with self.pool.acquire() as connection:
+                    for channel_name in channels:
+                        await self._execute_query_connection(
+                            connection=connection,
+                            query=self._make_dynamic_query(
+                                query=sql.queries["listen_queue"], channel_name=channel_name
+                            ),
+                        )
+                    await self._loop_notify(
+                        on_notification=on_notification, connection=connection
                     )
-                await self._loop_notify(
-                    on_notification=on_notification, connection=connection
-                )
+            except psycopg2.OperationalError:
+                # Connection failed, we need to reconnect
+                await asyncio.sleep(reconnect_interval)
+                continue
 
     @wrap_exceptions()
     async def _loop_notify(

--- a/procrastinate/contrib/aiopg/aiopg_connector.py
+++ b/procrastinate/contrib/aiopg/aiopg_connector.py
@@ -303,7 +303,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
 
     @wrap_exceptions()
     async def listen_notify(
-        self, on_notification: connector.Notify, channels: Iterable[str]
+        self, on_notification: connector.Notify, channels: Iterable[str], *, listen_notify_reconnect_interval: float = 2.0
     ) -> None:
         # We need to acquire a dedicated connection, and use the listen
         # query

--- a/procrastinate/contrib/django/django_connector.py
+++ b/procrastinate/contrib/django/django_connector.py
@@ -150,7 +150,7 @@ class DjangoConnector(connector.BaseAsyncConnector):
         on_notification: connector.Notify,
         channels: Iterable[str],
         *,
-        listen_notify_reconnect_interval: float = 2.0,
+        reconnect_interval: float = 2.0,
     ) -> None:
         raise NotImplementedError(
             "listen/notify is not supported with Django connector"

--- a/procrastinate/contrib/django/django_connector.py
+++ b/procrastinate/contrib/django/django_connector.py
@@ -146,7 +146,7 @@ class DjangoConnector(connector.BaseAsyncConnector):
             return list(self._dictfetch(cursor))
 
     async def listen_notify(
-        self, on_notification: connector.Notify, channels: Iterable[str]
+        self, on_notification: connector.Notify, channels: Iterable[str], *, listen_notify_reconnect_interval: float = 2.0
     ) -> None:
         raise NotImplementedError(
             "listen/notify is not supported with Django connector"

--- a/procrastinate/contrib/django/django_connector.py
+++ b/procrastinate/contrib/django/django_connector.py
@@ -146,7 +146,11 @@ class DjangoConnector(connector.BaseAsyncConnector):
             return list(self._dictfetch(cursor))
 
     async def listen_notify(
-        self, on_notification: connector.Notify, channels: Iterable[str], *, listen_notify_reconnect_interval: float = 2.0
+        self,
+        on_notification: connector.Notify,
+        channels: Iterable[str],
+        *,
+        listen_notify_reconnect_interval: float = 2.0,
     ) -> None:
         raise NotImplementedError(
             "listen/notify is not supported with Django connector"

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -570,7 +570,7 @@ class JobManager:
         await self.connector.listen_notify(
             on_notification=handle_notification,
             channels=get_channel_for_queues(queues=queues),
-            listen_notify_reconnect_interval=listen_notify_reconnect_interval,
+            reconnect_interval=listen_notify_reconnect_interval,
         )
 
     async def check_connection_async(self) -> bool:

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -537,6 +537,7 @@ class JobManager:
         *,
         on_notification: NotificationCallback,
         queues: Iterable[str] | None = None,
+        listen_notify_reconnect_interval: float = 2.0,
     ) -> None:
         """
         Listens to job notifications from the database, and invokes the callback each time an
@@ -553,6 +554,9 @@ class JobManager:
             If ``None``, all notification will be considered. If an iterable of
             queue names is passed, only defer operations on those queues will be
             considered. Defaults to ``None``
+        listen_notify_reconnect_interval : ``float``
+            Time in seconds to wait before attempting to reconnect after a connection
+            failure in ``listen_notify``. Default is 2.0 seconds.
         """
 
         async def handle_notification(channel: str, payload: str):
@@ -566,6 +570,7 @@ class JobManager:
         await self.connector.listen_notify(
             on_notification=handle_notification,
             channels=get_channel_for_queues(queues=queues),
+            listen_notify_reconnect_interval=listen_notify_reconnect_interval,
         )
 
     async def check_connection_async(self) -> bool:

--- a/procrastinate/psycopg_connector.py
+++ b/procrastinate/psycopg_connector.py
@@ -50,6 +50,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
         pool_factory: Callable[
             ..., psycopg_pool.AsyncConnectionPool
         ] = psycopg_pool.AsyncConnectionPool,
+        listen_notify_reconnect_interval: float = 2.0,
         **kwargs: Any,
     ):
         """
@@ -85,6 +86,9 @@ class PsycopgConnector(connector.BaseAsyncConnector):
             Default is ``psycopg_pool.AsyncConnectionPool``.
             You can set this to ``psycopg_pool.AsyncNullConnectionPool`` to disable
             pooling.
+        listen_notify_reconnect_interval :
+            Time in seconds to wait before attempting to reconnect after a connection
+            failure in ``listen_notify``. Default is 2.0 seconds.
         """
         self._async_pool: psycopg_pool.AsyncConnectionPool | None = None
         self._pool_factory: Callable[..., psycopg_pool.AsyncConnectionPool] = (
@@ -93,6 +97,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
         self._pool_externally_set: bool = False
         self._json_loads = json_loads
         self._json_dumps = json_dumps
+        self._listen_notify_reconnect_interval = listen_notify_reconnect_interval
         self._pool_args = kwargs
         self._sync_connector: connector.BaseConnector | None = None
 
@@ -271,7 +276,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
                     )
             except psycopg.OperationalError:
                 # Connection failed, we need to reconnect
-                await asyncio.sleep(2.0)
+                await asyncio.sleep(self._listen_notify_reconnect_interval)
                 continue
 
     @wrap_exceptions()

--- a/procrastinate/psycopg_connector.py
+++ b/procrastinate/psycopg_connector.py
@@ -254,7 +254,11 @@ class PsycopgConnector(connector.BaseAsyncConnector):
 
     @wrap_exceptions()
     async def listen_notify(
-        self, on_notification: connector.Notify, channels: Iterable[str], *, listen_notify_reconnect_interval: float = 2.0
+        self,
+        on_notification: connector.Notify,
+        channels: Iterable[str],
+        *,
+        listen_notify_reconnect_interval: float = 2.0,
     ) -> None:
         while True:
             try:

--- a/procrastinate/psycopg_connector.py
+++ b/procrastinate/psycopg_connector.py
@@ -275,7 +275,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
                     )
             except psycopg.OperationalError:
                 # Connection failed, we need to reconnect
-                await asyncio.sleep(listen_notify_reconnect_interval)
+                await asyncio.sleep(reconnect_interval)
                 continue
 
     @wrap_exceptions()

--- a/procrastinate/psycopg_connector.py
+++ b/procrastinate/psycopg_connector.py
@@ -258,7 +258,7 @@ class PsycopgConnector(connector.BaseAsyncConnector):
         on_notification: connector.Notify,
         channels: Iterable[str],
         *,
-        listen_notify_reconnect_interval: float = 2.0,
+        reconnect_interval: float = 2.0,
     ) -> None:
         while True:
             try:

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -91,7 +91,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         on_notification: connector.Notify,
         channels: Iterable[str],
         *,
-        listen_notify_reconnect_interval: float = 2.0,
+        reconnect_interval: float = 2.0,
     ) -> None:
         self.on_notification = on_notification
         self.notify_channels = list(channels)

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -87,7 +87,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         return await self.generic_execute(query, "all", **arguments)
 
     async def listen_notify(
-        self, on_notification: connector.Notify, channels: Iterable[str]
+        self, on_notification: connector.Notify, channels: Iterable[str], *, listen_notify_reconnect_interval: float = 2.0
     ) -> None:
         self.on_notification = on_notification
         self.notify_channels = list(channels)

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -87,7 +87,11 @@ class InMemoryConnector(connector.BaseAsyncConnector):
         return await self.generic_execute(query, "all", **arguments)
 
     async def listen_notify(
-        self, on_notification: connector.Notify, channels: Iterable[str], *, listen_notify_reconnect_interval: float = 2.0
+        self,
+        on_notification: connector.Notify,
+        channels: Iterable[str],
+        *,
+        listen_notify_reconnect_interval: float = 2.0,
     ) -> None:
         self.on_notification = on_notification
         self.notify_channels = list(channels)

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -28,6 +28,7 @@ WORKER_NAME = "worker"
 WORKER_CONCURRENCY = 1  # maximum number of parallel jobs
 FETCH_JOB_POLLING_INTERVAL = 5.0  # seconds
 ABORT_JOB_POLLING_INTERVAL = 5.0  # seconds
+LISTEN_NOTIFY_RECONNECT_INTERVAL = 2.0  # seconds
 
 
 class Worker:
@@ -42,6 +43,7 @@ class Worker:
         abort_job_polling_interval: float = ABORT_JOB_POLLING_INTERVAL,
         shutdown_graceful_timeout: float | None = None,
         listen_notify: bool = True,
+        listen_notify_reconnect_interval: float = LISTEN_NOTIFY_RECONNECT_INTERVAL,
         delete_jobs: str | jobs.DeleteJobCondition | None = None,
         additional_context: dict[str, Any] | None = None,
         install_signal_handlers: bool = True,
@@ -56,6 +58,7 @@ class Worker:
         self.fetch_job_polling_interval = fetch_job_polling_interval
         self.abort_job_polling_interval = abort_job_polling_interval
         self.listen_notify = listen_notify
+        self.listen_notify_reconnect_interval = listen_notify_reconnect_interval
         self.delete_jobs = (
             jobs.DeleteJobCondition(delete_jobs)
             if isinstance(delete_jobs, str)
@@ -541,6 +544,7 @@ class Worker:
             listener_coro = self.app.job_manager.listen_for_jobs(
                 on_notification=self._handle_notification,
                 queues=self.queues,
+                listen_notify_reconnect_interval=self.listen_notify_reconnect_interval,
             )
             side_tasks.append(asyncio.create_task(listener_coro, name="listener"))
         return side_tasks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,9 @@ def psycopg_connection_params(connection_params, make_psycopg_connection_params)
 
 @pytest.fixture
 async def not_opened_psycopg_connector(psycopg_connection_params):
-    yield async_psycopg_connector_module.PsycopgConnector(**psycopg_connection_params)
+    yield async_psycopg_connector_module.PsycopgConnector(
+        listen_notify_reconnect_interval=0.0, **psycopg_connection_params
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,9 +198,7 @@ def psycopg_connection_params(connection_params, make_psycopg_connection_params)
 
 @pytest.fixture
 async def not_opened_psycopg_connector(psycopg_connection_params):
-    yield async_psycopg_connector_module.PsycopgConnector(
-        **psycopg_connection_params
-    )
+    yield async_psycopg_connector_module.PsycopgConnector(**psycopg_connection_params)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,7 @@ def psycopg_connection_params(connection_params, make_psycopg_connection_params)
 @pytest.fixture
 async def not_opened_psycopg_connector(psycopg_connection_params):
     yield async_psycopg_connector_module.PsycopgConnector(
-        listen_notify_reconnect_interval=0.0, **psycopg_connection_params
+        **psycopg_connection_params
     )
 
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -70,7 +70,8 @@ async def test_worker(entrypoint, cli_app, mocker):
     result = await entrypoint(
         "worker "
         "--queues a,b --name=w1 --fetch-job-polling-interval=8.3 --abort-job-polling-interval=20 "
-        "--one-shot --concurrency=10 --no-listen-notify --delete-jobs=always"
+        "--one-shot --concurrency=10 --no-listen-notify --delete-jobs=always "
+        "--listen-notify-reconnect-interval=5.5"
     )
 
     assert "Launching a worker on a, b" in result.stderr.strip()
@@ -84,6 +85,7 @@ async def test_worker(entrypoint, cli_app, mocker):
         wait=False,
         listen_notify=False,
         delete_jobs=jobs.DeleteJobCondition.ALWAYS,
+        listen_notify_reconnect_interval=5.5,
     )
 
 

--- a/tests/unit/contrib/aiopg/test_aiopg_connector.py
+++ b/tests/unit/contrib/aiopg/test_aiopg_connector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import collections
 import asyncio
+import collections
 
 import psycopg2
 import pytest

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,7 +16,8 @@ from procrastinate.connector import BaseConnector
     "verbosity, log_level", [(0, "INFO"), (1, "DEBUG"), (2, "DEBUG")]
 )
 def test_get_log_level(verbosity, log_level):
-    assert cli.get_log_level(verbosity=verbosity) == getattr(logging, log_level)
+    assert cli.get_log_level(
+        verbosity=verbosity) == getattr(logging, log_level)
 
 
 def test_configure_logging(mocker, caplog):
@@ -29,7 +30,8 @@ def test_configure_logging(mocker, caplog):
     config.assert_called_once_with(
         level=logging.DEBUG, format="{message}, yay!", style="{"
     )
-    records = [record for record in caplog.records if record.action == "set_log_level"]
+    records = [
+        record for record in caplog.records if record.action == "set_log_level"]
     assert len(records) == 1
     assert records[0].value == "DEBUG"
 
@@ -54,6 +56,10 @@ def test_main(mocker):
         (
             ["worker", "--delete-jobs", "never"],
             {"command": "worker", "delete_jobs": jobs.DeleteJobCondition.NEVER},
+        ),
+        (
+            ["worker", "--listen-notify-reconnect-interval", "5.0"],
+            {"command": "worker", "listen_notify_reconnect_interval": 5.0},
         ),
         (["defer", "x"], {"command": "defer", "task": "x"}),
         (["defer", "x", "{}"], {"command": "defer", "task": "x", "json_args": "{}"}),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,8 +16,7 @@ from procrastinate.connector import BaseConnector
     "verbosity, log_level", [(0, "INFO"), (1, "DEBUG"), (2, "DEBUG")]
 )
 def test_get_log_level(verbosity, log_level):
-    assert cli.get_log_level(
-        verbosity=verbosity) == getattr(logging, log_level)
+    assert cli.get_log_level(verbosity=verbosity) == getattr(logging, log_level)
 
 
 def test_configure_logging(mocker, caplog):
@@ -30,8 +29,7 @@ def test_configure_logging(mocker, caplog):
     config.assert_called_once_with(
         level=logging.DEBUG, format="{message}, yay!", style="{"
     )
-    records = [
-        record for record in caplog.records if record.action == "set_log_level"]
+    records = [record for record in caplog.records if record.action == "set_log_level"]
     assert len(records) == 1
     assert records[0].value == "DEBUG"
 

--- a/tests/unit/test_psycopg_connector.py
+++ b/tests/unit/test_psycopg_connector.py
@@ -36,8 +36,7 @@ async def test_wrap_exceptions_success():
 async def test_listen_notify_reconnect_interval(mocker):
     connector = psycopg_connector.PsycopgConnector()
     mock_connection = mocker.AsyncMock()
-    mock_connection.execute.side_effect = psycopg.OperationalError(
-        "Connection lost")
+    mock_connection.execute.side_effect = psycopg.OperationalError("Connection lost")
 
     @asynccontextmanager
     async def mock_get_connection():
@@ -64,7 +63,7 @@ async def test_listen_notify_reconnect_interval(mocker):
         await connector.listen_notify(
             mocker.AsyncMock(),
             ["test_channel"],
-            reconnect_interval=expected_sleep_duration
+            reconnect_interval=expected_sleep_duration,
         )
 
     assert sleep_call_count >= 1
@@ -86,8 +85,7 @@ def test_wrap_exceptions_applied(method_name, connector):
 
 
 async def test_open_async_no_pool_specified(mocker, connector):
-    mocker.patch.object(connector, "_create_pool",
-                        return_value=mocker.AsyncMock())
+    mocker.patch.object(connector, "_create_pool", return_value=mocker.AsyncMock())
 
     await connector.open_async()
 

--- a/tests/unit/test_psycopg_connector.py
+++ b/tests/unit/test_psycopg_connector.py
@@ -33,16 +33,6 @@ async def test_wrap_exceptions_success():
     assert await corofunc(1, 2) == (1, 2)
 
 
-def test_init_default_listen_notify_reconnect_interval():
-    connector = psycopg_connector.PsycopgConnector()
-    assert connector._listen_notify_reconnect_interval == 2.0
-
-
-def test_init_custom_listen_notify_reconnect_interval():
-    connector = psycopg_connector.PsycopgConnector(listen_notify_reconnect_interval=5.0)
-    assert connector._listen_notify_reconnect_interval == 5.0
-
-
 @pytest.mark.parametrize(
     "connector, expected_sleep_duration",
     [

--- a/tests/unit/test_psycopg_connector.py
+++ b/tests/unit/test_psycopg_connector.py
@@ -11,7 +11,7 @@ from procrastinate import exceptions, psycopg_connector
 
 @pytest.fixture
 def connector():
-    return psycopg_connector.PsycopgConnector()
+    return psycopg_connector.PsycopgConnector(listen_notify_reconnect_interval=0.0)
 
 
 async def test_wrap_exceptions_wraps():

--- a/tests/unit/test_psycopg_connector.py
+++ b/tests/unit/test_psycopg_connector.py
@@ -36,8 +36,7 @@ async def test_wrap_exceptions_success():
 async def test_listen_notify_reconnect_interval(mocker):
     connector = psycopg_connector.PsycopgConnector()
     mock_connection = mocker.AsyncMock()
-    mock_connection.execute.side_effect = psycopg.OperationalError(
-        "Connection lost")
+    mock_connection.execute.side_effect = psycopg.OperationalError("Connection lost")
 
     @asynccontextmanager
     async def mock_get_connection():
@@ -64,7 +63,7 @@ async def test_listen_notify_reconnect_interval(mocker):
         await connector.listen_notify(
             mocker.AsyncMock(),
             ["test_channel"],
-            listen_notify_reconnect_interval=expected_sleep_duration
+            listen_notify_reconnect_interval=expected_sleep_duration,
         )
 
     assert sleep_call_count >= 1
@@ -86,8 +85,7 @@ def test_wrap_exceptions_applied(method_name, connector):
 
 
 async def test_open_async_no_pool_specified(mocker, connector):
-    mocker.patch.object(connector, "_create_pool",
-                        return_value=mocker.AsyncMock())
+    mocker.patch.object(connector, "_create_pool", return_value=mocker.AsyncMock())
 
     await connector.open_async()
 

--- a/tests/unit/test_psycopg_connector.py
+++ b/tests/unit/test_psycopg_connector.py
@@ -39,30 +39,30 @@ def test_init_default_listen_notify_reconnect_interval():
 
 
 def test_init_custom_listen_notify_reconnect_interval():
-    connector = psycopg_connector.PsycopgConnector(
-        listen_notify_reconnect_interval=5.0)
+    connector = psycopg_connector.PsycopgConnector(listen_notify_reconnect_interval=5.0)
     assert connector._listen_notify_reconnect_interval == 5.0
 
 
 @pytest.mark.parametrize(
     "connector, expected_sleep_duration",
     [
-        (psycopg_connector.PsycopgConnector(
-            listen_notify_reconnect_interval=1.5), 1.5),
+        (psycopg_connector.PsycopgConnector(listen_notify_reconnect_interval=1.5), 1.5),
         (psycopg_connector.PsycopgConnector(), 2.0),
-    ]
+    ],
 )
-async def test_listen_notify_reconnect_interval(mocker, connector, expected_sleep_duration):
+async def test_listen_notify_reconnect_interval(
+    mocker, connector, expected_sleep_duration
+):
     mock_connection = mocker.AsyncMock()
-    mock_connection.execute.side_effect = psycopg.OperationalError(
-        "Connection lost")
+    mock_connection.execute.side_effect = psycopg.OperationalError("Connection lost")
 
     @asynccontextmanager
     async def mock_get_connection():
         yield mock_connection
 
-    mocker.patch.object(connector, '_get_standalone_connection',
-                        side_effect=mock_get_connection)
+    mocker.patch.object(
+        connector, "_get_standalone_connection", side_effect=mock_get_connection
+    )
 
     sleep_call_count = 0
 
@@ -73,8 +73,8 @@ async def test_listen_notify_reconnect_interval(mocker, connector, expected_slee
             raise asyncio.CancelledError("Stop the loop")
         assert duration == expected_sleep_duration
 
-    mocker.patch('asyncio.sleep', side_effect=mock_sleep)
-    mocker.patch.object(connector, '_loop_notify')
+    mocker.patch("asyncio.sleep", side_effect=mock_sleep)
+    mocker.patch.object(connector, "_loop_notify")
 
     with pytest.raises(asyncio.CancelledError):
         await connector.listen_notify(mocker.AsyncMock(), ["test_channel"])

--- a/tests/unit/test_psycopg_connector.py
+++ b/tests/unit/test_psycopg_connector.py
@@ -36,7 +36,8 @@ async def test_wrap_exceptions_success():
 async def test_listen_notify_reconnect_interval(mocker):
     connector = psycopg_connector.PsycopgConnector()
     mock_connection = mocker.AsyncMock()
-    mock_connection.execute.side_effect = psycopg.OperationalError("Connection lost")
+    mock_connection.execute.side_effect = psycopg.OperationalError(
+        "Connection lost")
 
     @asynccontextmanager
     async def mock_get_connection():
@@ -63,7 +64,7 @@ async def test_listen_notify_reconnect_interval(mocker):
         await connector.listen_notify(
             mocker.AsyncMock(),
             ["test_channel"],
-            listen_notify_reconnect_interval=expected_sleep_duration,
+            reconnect_interval=expected_sleep_duration
         )
 
     assert sleep_call_count >= 1
@@ -85,7 +86,8 @@ def test_wrap_exceptions_applied(method_name, connector):
 
 
 async def test_open_async_no_pool_specified(mocker, connector):
-    mocker.patch.object(connector, "_create_pool", return_value=mocker.AsyncMock())
+    mocker.patch.object(connector, "_create_pool",
+                        return_value=mocker.AsyncMock())
 
     await connector.open_async()
 


### PR DESCRIPTION
Hey 👋 

We stumbled over problems, when loosing the connection to the database.
After connection loss (stopping and restarting our db), procrastinate continued to work, but only via polling.

This is just the simplest approach trying to reestablish the listen for new jobs.
Let's discuss how we can finish/polish this, if this should be part of the library :) 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
