### PR TITLE
Clamp `datetime_from_timedelta_params` instead of crashing.

### DIFF
--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -157,6 +157,10 @@ def utcnow() -> datetime.datetime:
     return datetime.datetime.now(tz=datetime.timezone.utc)
 
 
+def utcmax() -> datetime.datetime:
+    return datetime.datetime.max.replace(tzinfo=datetime.timezone.utc)
+
+
 def parse_datetime(raw: str) -> datetime.datetime:
     try:
         # this parser is the stricter one, so we try it first
@@ -321,7 +325,10 @@ def async_context_decorator(func: Callable) -> Callable:
 
 
 def datetime_from_timedelta_params(params: TimeDeltaParams) -> datetime.datetime:
-    return utcnow() + datetime.timedelta(**params)
+    try:
+        return utcnow() + datetime.timedelta(**params)
+    except OverflowError:
+        return utcmax()
 
 
 def queues_display(queues: Iterable[str] | None) -> str:


### PR DESCRIPTION
Closes #1462

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
