### PR TITLE
added timezone support for cron schedules in periodic tasks

### DIFF
--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -9,6 +9,7 @@ from typing_extensions import Concatenate, ParamSpec, TypeVar, Unpack
 
 from procrastinate import exceptions, jobs, periodic, retry, utils
 from procrastinate.job_context import JobContext
+from zoneinfo import ZoneInfo
 
 if TYPE_CHECKING:
     from procrastinate.tasks import ConfigureTaskOptions, Task
@@ -195,6 +196,7 @@ class Blueprint:
                 task=periodic_task.task,
                 cron=periodic_task.cron,
                 periodic_id=periodic_task.periodic_id,
+                tzinfo=periodic_task.tzinfo,
                 configure_kwargs=periodic_task.configure_kwargs,
             )
 
@@ -359,6 +361,7 @@ class Blueprint:
         *,
         cron: str,
         periodic_id: str = "",
+        tzinfo: str | None | ZoneInfo = None,
         **configure_kwargs: Unpack[ConfigureTaskOptions],
     ):
         """
@@ -371,11 +374,17 @@ class Blueprint:
             Cron-like string. Optionally add a 6th column for seconds.
         periodic_id :
             Task name suffix. Used to distinguish periodic tasks with different kwargs.
-        **kwargs :
-            Additional parameters are passed to `Task.configure`.
+        tzinfo :
+            Timezone in which the cron expression should be interpreted. Accepts a
+            timezone name string (e.g., "Africa/Blantyre"), a `zoneinfo.ZoneInfo` instance,
+            or `None`. When `None` (the default), the underlying `croniter` library
+            will interpret the schedule in UTC (the current behaviour).
+        **configure_kwargs :
+            Additional parameters are passed to ``Task.configure``.
         """
+
         return self.periodic_registry.periodic_decorator(
-            cron=cron, periodic_id=periodic_id, **configure_kwargs
+            cron=cron, periodic_id=periodic_id, tzinfo=tzinfo, **configure_kwargs
         )
 
     def will_configure_task(self) -> None:

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -4,12 +4,12 @@ import functools
 import logging
 import sys
 from typing import TYPE_CHECKING, Callable, Literal, Union, cast, overload
+from zoneinfo import ZoneInfo
 
 from typing_extensions import Concatenate, ParamSpec, TypeVar, Unpack
 
 from procrastinate import exceptions, jobs, periodic, retry, utils
 from procrastinate.job_context import JobContext
-from zoneinfo import ZoneInfo
 
 if TYPE_CHECKING:
     from procrastinate.tasks import ConfigureTaskOptions, Task

--- a/procrastinate/periodic.py
+++ b/procrastinate/periodic.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
 import functools
 import logging
 import time
@@ -37,7 +36,7 @@ class PeriodicTask(Generic[P, R, Args]):
     cron: str
     periodic_id: str
     configure_kwargs: tasks.ConfigureTaskOptions
-    tzinfo:str|None|ZoneInfo=None
+    tzinfo: str | None | ZoneInfo = None
 
     @cached_property
     def croniter(self) -> croniter.croniter:
@@ -70,7 +69,7 @@ class PeriodicRegistry:
         self,
         cron: str,
         periodic_id: str,
-        tzinfo:str|None|ZoneInfo=None,
+        tzinfo: str | None | ZoneInfo = None,
         **configure_kwargs: Unpack[tasks.ConfigureTaskOptions],
     ) -> Callable[[tasks.Task[P, R, Concatenate[int, Args]]], tasks.Task[P, R, Args]]:
         """
@@ -78,6 +77,7 @@ class PeriodicRegistry:
         launch. This decorator should not be used directly, ``@app.periodic()`` is meant
         to be used instead.
         """
+
         def wrapper(
             task: tasks.Task[P, R, Concatenate[int, Args]],
         ) -> tasks.Task[P, R, Args]:
@@ -98,8 +98,7 @@ class PeriodicRegistry:
         cron: str,
         periodic_id: str,
         configure_kwargs: tasks.ConfigureTaskOptions,
-        tzinfo:str|None|ZoneInfo=None,
-
+        tzinfo: str | None | ZoneInfo = None,
     ) -> PeriodicTask[P, R, Concatenate[int, Args]]:
         key = (task.name, periodic_id)
         if key in self.periodic_tasks:
@@ -125,7 +124,7 @@ class PeriodicRegistry:
             cron=cron,
             periodic_id=periodic_id,
             configure_kwargs=configure_kwargs,
-            tzinfo=tzinfo
+            tzinfo=tzinfo,
         )
         return periodic_task
 


### PR DESCRIPTION
**Closes #1472**

This PR adds native timezone support to Procrastinate’s periodic task scheduler.

The `Blueprint.periodic` decorator now accepts a `tzinfo` argument, which can be either a string or a `zoneinfo.ZoneInfo` object. When provided, croniter will evaluate the cron expression in the specified timezone rather than defaulting to UTC.

Previously, users had to manually convert local times to UTC to ensure tasks ran at the intended hours. This often led to confusion and misaligned schedules. With this enhancement, users can define periodic tasks directly in their local timezone, improving predictability and reducing the risk of scheduling errors.

### Key Changes
- The `tzinfo` attribute is now set on the `croniter` instance within `PeriodicTask`.

### Example Usage
```python
from zoneinfo import ZoneInfo

tzinfo = "Africa/Blantyre" or ZoneInfo("Africa/Blantyre")  # UTC+2

@app.periodic(cron="* 8-17 * * *", tzinfo=tzinfo, ...)
@app.task(...)
def between_5_and_7(timestamp): ...
```

Without `tzinfo`: runs from 10 AM to 7 PM UTC  
With `tzinfo`: runs from 8 AM to 5 PM local time



<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
