### PR TITLE
Fix migration failure for missing procrastinate_jobs_queue_name_idx

### DIFF
--- a/procrastinate/sql/migrations/00.11.00_04_add_jobs_queue_name_idx.sql
+++ b/procrastinate/sql/migrations/00.11.00_04_add_jobs_queue_name_idx.sql
@@ -1,3 +1,2 @@
 -- Add index on queue_name for better performance when querying jobs by queue
 CREATE INDEX IF NOT EXISTS procrastinate_jobs_queue_name_idx ON procrastinate_jobs(queue_name);
-


### PR DESCRIPTION
Closes #1461

The index procrastinate_jobs_queue_name_idx was added to schema.sql in v0.11.0 but lacked a corresponding migration. The migration 03.00.00_50_post_cancel_notification.sql tried to rename this index, which failed for users who only used migrations to set up their database.

This fix adds the missing historical migration file at the correct version (00.11.00_04_add_jobs_queue_name_idx.sql) to create the index. This allows the later migration to simply rename it as originally intended.

### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
