### PR TITLE
Fixes PROCRASTINATE_VERBOSITY to PROCRASTINATE_VERBOSE and adds a new --log-level option for granular log level control.

### DIFF
--- a/docs/howto/basics/command_line.md
+++ b/docs/howto/basics/command_line.md
@@ -56,21 +56,39 @@ In both case, the app you specify must have an asynchronous connector.
 
 ## Logging
 
-Three different options allow you to control how the command-line tool should log
-events:
+Several options allow you to control how the command-line tool should log events:
 
-- Verbosity controls the log level (you'll see message of this level and above):
+- **Verbosity** controls the log level (you'll see messages of this level and above):
 
-  | Flags | Environment equivalent    | Log level |
-  | ----- | ------------------------- | --------- |
-  |       | PROCRASTINATE_VERBOSITY=0 | `warning` |
-  | -v    | PROCRASTINATE_VERBOSITY=1 | `info`    |
-  | -vv   | PROCRASTINATE_VERBOSITY=2 | `debug`   |
+  | Flags          | Environment equivalent  | Log level |
+  | -------------- | ----------------------- | --------- |
+  |                | PROCRASTINATE_VERBOSE=0 | `info`    |
+  | -v (or higher) | PROCRASTINATE_VERBOSE=1 | `debug`   |
 
-- Log format: `--log-format=` / `PROCRASTINATE_LOG_FORMAT=` lets you control how
+  Note: Values beyond 1 have no additional effect. When both environment variable
+  and CLI flag are used, the flag value is added to the environment variable value
+  (e.g., `PROCRASTINATE_VERBOSE=1` with `-v` results in verbosity=2, which gives `debug`).
+
+- **Log level** allows explicit control over the logging level (mutually exclusive with `-v`):
+
+  `--log-level=LEVEL` / `PROCRASTINATE_LOG_LEVEL=LEVEL` where `LEVEL` is one of:
+  `debug`, `info`, `warning`, `error`, or `critical`.
+
+  This option provides access to log levels not available through `-v` flags,
+  such as `warning`, `error`, and `critical`. You cannot use `--log-level` and
+  `-v` together.
+
+  Examples:
+
+  ```console
+  $ procrastinate --log-level=warning worker
+  $ PROCRASTINATE_LOG_LEVEL=error procrastinate worker
+  ```
+
+- **Log format**: `--log-format=` / `PROCRASTINATE_LOG_FORMAT=` lets you control how
   the log line will be formatted. It uses `%`-style placeholders by default.
 
-- Log format style: `--log-format-style=` / `PROCRASTINATE_LOG_FORMAT_STYLE=`
+- **Log format style**: `--log-format-style=` / `PROCRASTINATE_LOG_FORMAT_STYLE=`
   lets you choose different styles for the log-format, such as `{` or `$`.
 
 For more information on log formats, refer to the [Python documentation](https://docs.python.org/3/library/logging.html?highlight=logging#logrecord-attributes)

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shlex
 import sys
+import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal
 
@@ -60,6 +61,16 @@ def configure_logging(
 
     This function only performs operations - all logic is in get_log_level().
     """
+    # Issue deprecation warning when -v/--verbose is actively used
+    if verbosity is not None and verbosity > 0:
+        warnings.warn(
+            "The -v/--verbose flag and PROCRASTINATE_VERBOSE environment variable "
+            "are deprecated and will be removed in a future version. "
+            "Use --log-level or PROCRASTINATE_LOG_LEVEL instead.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+
     level = get_log_level(verbosity=verbosity, log_level=log_level)
     logging.basicConfig(level=level, format=format, style=style)
     level_name = logging.getLevelName(level)

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -57,10 +57,7 @@ def configure_logging(
     format: str = logging.BASIC_FORMAT,
     style: Style = "%",
 ) -> None:
-    """Configure the Python logging system.
-
-    This function only performs operations - all logic is in get_log_level().
-    """
+    """Configure the Python logging system."""
     # Issue deprecation warning when -v/--verbose is actively used
     if verbosity is not None and verbosity > 0:
         warnings.warn(

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -52,6 +52,7 @@ async def test_cli(entrypoint):
     assert result.stderr.startswith("usage:")
 
 
+@pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 async def test_cli_logging_configuration(entrypoint, cli_app):
     result = await entrypoint(
         "--verbose --log-format {message},yay! --log-format-style { healthchecks"


### PR DESCRIPTION
Closes #1405  

Corrected the documented verbosity environment variable
(`PROCRASTINATE_VERBOSE`) and introducing a new `--log-level` option for
explicit log level control.

This removes a documentation/code mismatch and gives users precise control
over logging while preserving existing behavior.

---

## Problem

### 1. Documentation / Code Mismatch

The documentation referenced `PROCRASTINATE_VERBOSITY`, but the CLI actually
uses `PROCRASTINATE_VERBOSE`. Users following the docs had their environment
variable ignored.

### 2. Limited Log Level Control

The CLI only supported:
- `INFO` (default)
- `DEBUG` (via `-v`)

There was no way to explicitly select standard logging levels such as
`warning`, `error`, or `critical`, which are commonly needed in production
and monitoring environments.

---

## Solution

- **Documentation fix**
  - Corrected all references to `PROCRASTINATE_VERBOSE`
  - Updated examples and tables to reflect actual behavior

- **Explicit log level support**
  - Added `--log-level` option (`debug`, `info`, `warning`, `error`, `critical`)
  - Added `PROCRASTINATE_LOG_LEVEL` environment variable

- **Clear, predictable behavior**
  - `-v/--verbose` and `--log-level` are mutually exclusive
  - Explicit log level takes precedence over verbosity
  - CLI flags override environment variables

- **Backward compatible**
  - Existing `-v` behavior unchanged
  - `PROCRASTINATE_VERBOSE` continues to work
  - Default log level remains `INFO`

---

## Behavior Summary

| Method | Result |
|------|------|
| Default | `INFO` |
| `-v` / `PROCRASTINATE_VERBOSE=1` | `DEBUG` |
| `--log-level=warning` / `PROCRASTINATE_LOG_LEVEL=warning` | `WARNING` and above |
| `--log-level=error` | `ERROR` and `CRITICAL` |
| `-v` + `--log-level` | ❌ Error (mutually exclusive) |

---

## Testing

-Well tested with comprehensive unit tests.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --log-level CLI option (mutually exclusive with -v/--verbose); explicit log level overrides verbosity. Using -v emits a deprecation warning.

* **Documentation**
  * Updated logging guide: VERBOSITY→VERBOSE, introduced PROCRASTINATE_LOG_LEVEL, clarified env/CLI precedence, verbosity stacking rules, log level examples, and log format/style guidance.

* **Tests**
  * Expanded CLI logging tests covering precedence, environment interaction, mutual exclusivity, and deprecation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->