### PR TITLE
feat: add external connection support for atomic job deferral

### DIFF
--- a/docs/howto/production.md
+++ b/docs/howto/production.md
@@ -13,6 +13,7 @@ production/migrations
 production/concurrency
 production/monitoring
 production/connections
+production/external_connection
 production/schema
 production/delete_finished_jobs
 production/retry_stalled_jobs

--- a/docs/howto/production/external_connection.md
+++ b/docs/howto/production/external_connection.md
@@ -1,0 +1,91 @@
+# Using an external database connection
+
+Procrastinate supports deferring jobs on an externally-managed database connection.
+This lets you insert the job within the same transaction as your own database
+operations, enabling patterns like the **transactional outbox**.
+
+## When to use this
+
+If you need the job to be created **atomically** with other database writes (e.g.
+inserting a row into your own table and deferring a task that processes it), pass your
+connection to `configure(connection=...)`. The job INSERT will execute on your
+connection, inside your transaction. You are responsible for committing.
+
+## Sync example (psycopg)
+
+```python
+import psycopg
+from procrastinate import App, SyncPsycopgConnector
+
+app = App(connector=SyncPsycopgConnector(conninfo="..."))
+app.open()
+
+@app.task
+def process_order(order_id):
+    ...
+
+with psycopg.connect("...") as conn:
+    conn.autocommit = False
+    conn.execute("INSERT INTO orders (id, ...) VALUES (%s, ...)", [42])
+    process_order.configure(connection=conn).defer(order_id=42)
+    conn.commit()  # both the order row and the job are committed together
+```
+
+## Async example (psycopg)
+
+```python
+import psycopg
+from procrastinate import App, PsycopgConnector
+
+app = App(connector=PsycopgConnector(conninfo="..."))
+await app.open_async()
+
+@app.task
+def process_order(order_id):
+    ...
+
+async with await psycopg.AsyncConnection.connect("...") as conn:
+    conn.autocommit = False
+    await conn.execute("INSERT INTO orders (id, ...) VALUES (%s, ...)", [42])
+    await process_order.configure(connection=conn).defer_async(order_id=42)
+    await conn.commit()
+```
+
+## SQLAlchemy example
+
+```python
+from procrastinate import App
+from procrastinate.contrib.sqlalchemy import SQLAlchemyPsycopg2Connector
+
+connector = SQLAlchemyPsycopg2Connector(dsn="postgresql+psycopg2:///mydb")
+app = App(connector=connector)
+app.open()
+
+@app.task
+def process_order(order_id):
+    ...
+
+with connector.engine.connect() as conn:
+    conn.exec_driver_sql("INSERT INTO orders (id) VALUES (%s)", [42])
+    process_order.configure(connection=conn).defer(order_id=42)
+    conn.commit()
+```
+
+## Supported connectors
+
+- `SyncPsycopgConnector` — pass a `psycopg.Connection`
+- `PsycopgConnector` — pass a `psycopg.AsyncConnection`
+- `SQLAlchemyPsycopg2Connector` — pass a `sqlalchemy.engine.Connection`
+
+Other connectors will raise a `ConnectorException` if `connection` is provided.
+
+## Important notes
+
+- **NOTIFY is delayed**: The database NOTIFY that wakes workers fires when you
+  commit. This is expected and acceptable.
+- **Error handling**: Errors from the job INSERT (e.g. queueing lock violations)
+  are wrapped as usual via procrastinate's exception hierarchy, but they may abort
+  your transaction. Use savepoints if you need to isolate the defer from the rest
+  of your transaction.
+- **No validation**: Procrastinate does not validate the connection type. Passing
+  the wrong type will produce a runtime error from the database driver.

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -62,6 +62,20 @@ class BaseConnector:
     ) -> list[dict[str, Any]]:
         raise exceptions.SyncConnectorConfigurationError
 
+    def execute_query_all_with_connection(
+        self, connection: Any, query: LiteralString, **arguments: Any
+    ) -> list[dict[str, Any]]:
+        raise exceptions.ConnectorException(
+            f"{type(self).__name__} does not support external connections"
+        )
+
+    async def execute_query_all_async_with_connection(
+        self, connection: Any, query: LiteralString, **arguments: Any
+    ) -> list[dict[str, Any]]:
+        raise exceptions.ConnectorException(
+            f"{type(self).__name__} does not support external connections"
+        )
+
     async def listen_notify(
         self,
         on_notification: Notify,
@@ -102,6 +116,16 @@ class BaseAsyncConnector(BaseConnector):
         self, query: LiteralString, **arguments: Any
     ) -> list[dict[str, Any]]:
         return utils.async_to_sync(self.execute_query_all_async, query, **arguments)
+
+    def execute_query_all_with_connection(
+        self, connection: Any, query: LiteralString, **arguments: Any
+    ) -> list[dict[str, Any]]:
+        return utils.async_to_sync(
+            self.execute_query_all_async_with_connection,
+            connection,
+            query,
+            **arguments,
+        )
 
     async def listen_notify(
         self, on_notification: Notify, channels: Iterable[str]

--- a/procrastinate/contrib/sqlalchemy/psycopg2_connector.py
+++ b/procrastinate/contrib/sqlalchemy/psycopg2_connector.py
@@ -192,3 +192,16 @@ class SQLAlchemyPsycopg2Connector(connector.BaseConnector):
             # psycopg2's type say it returns a tuple, but it actually returns a
             # dict when configured with RealDictCursor
             return mapping.all()  # pyright: ignore[reportReturnType]
+
+    @wrap_exceptions()
+    def execute_query_all_with_connection(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        connection: sqlalchemy.engine.Connection,
+        query: str,
+        **arguments: Any,
+    ) -> list[Mapping[str, Any]]:
+        cursor_result = connection.exec_driver_sql(
+            PERCENT_PATTERN.sub("%%", query), self._wrap_json(arguments)
+        )
+        mapping = cursor_result.mappings()
+        return mapping.all()  # pyright: ignore[reportReturnType]

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -89,6 +89,16 @@ class InMemoryConnector(connector.BaseAsyncConnector):
     ) -> list[dict[str, Any]]:
         return await self.generic_execute(query, "all", **arguments)
 
+    def execute_query_all_with_connection(
+        self, connection: Any, query: str, **arguments: Any
+    ) -> list[dict[str, Any]]:
+        return utils.async_to_sync(self.execute_query_all_async, query, **arguments)
+
+    async def execute_query_all_async_with_connection(
+        self, connection: Any, query: str, **arguments: Any
+    ) -> list[dict[str, Any]]:
+        return await self.execute_query_all_async(query, **arguments)
+
     async def listen_notify(
         self, on_notification: connector.Notify, channels: Iterable[str]
     ) -> None:

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -159,6 +159,19 @@ def test_task_configure_override_queue(app):
     assert job.queue == "other_queue"
 
 
+def test_configure_task_connection(job_manager):
+    mock_conn = object()
+    deferrer = tasks.configure_task(
+        name="my_name", job_manager=job_manager, connection=mock_conn
+    )
+    assert deferrer.connection is mock_conn
+
+
+def test_configure_task_no_connection(job_manager):
+    deferrer = tasks.configure_task(name="my_name", job_manager=job_manager)
+    assert deferrer.connection is None
+
+
 def test_task_get_retry_exception_none(app):
     task = tasks.Task(task_func, blueprint=app, queue="queue")
     job = task.configure().job


### PR DESCRIPTION
Allow users to pass their own database connection when deferring jobs via task.configure(connection=conn).defer(), enabling atomic deferral within user-managed transactions.

Adds separate execute_query_all_*_with_connection methods rather than adding an optional connection param to the existing execute_query_all_* methods, to avoid breaking changes to the connector interface.

Supported by SyncPsycopgConnector, PsycopgConnector, and SQLAlchemyPsycopg2Connector. Unsupported connectors raise ConnectorException with a clear message.


Closes #1500

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Defer jobs using an externally managed, transaction-scoped database connection (sync & async); job persistence now follows the caller’s commit/rollback.

* **Documentation**
  * Added a how-to guide with usage patterns and examples for using external connections with supported connectors.

* **Tests**
  * Expanded integration and unit tests validating external-connection deferral behavior and connector handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->