### PR TITLE
[django][admin] Ignore safely tasks already enqueued.

### DIFF
--- a/procrastinate/contrib/django/admin.py
+++ b/procrastinate/contrib/django/admin.py
@@ -146,7 +146,7 @@ class ProcrastinateJobAdmin(admin.ModelAdmin):
         for job in queryset.filter(
             status__in=(Status.FAILED.value, Status.DOING.value)
         ):
-            with transaction.atomic(), suppress(AlreadyEnqueued):
+            with suppress(AlreadyEnqueued), transaction.atomic():
                 p_app.job_manager.retry_job_by_id(
                     job.id, utils.utcnow(), job.priority, job.queue_name, job.lock
                 )


### PR DESCRIPTION
Provides, in my opinion, a more user friendly experience, by allowing the submission to work, even if duplicate jobs have been selected.

It could be tedious to expect users to perform a strict selection by eliminating duplicated entries. Happy path scenario:
 User selects 1 page of failed jobs to retry.
    only the new one will be accepted for a retry, and
    will safely keep the other ones for a later attempt.
 User repeats until all failed jobs have been retried.


<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry operations in the Django admin now run inside a database transaction for improved reliability.
  * Retry attempts now suppress duplicate-enqueue errors to reduce noisy failures and improve admin behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->