### PR TITLE
Provide a stronger type hint for `App.open_async()`

### DIFF
--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -374,7 +374,7 @@ class App(blueprints.Blueprint):
 
     def open_async(
         self, pool: connector_module.Pool | None = None
-    ) -> utils.AwaitableContext:
+    ) -> utils.AwaitableContext[App]:
         """
         Open the app asynchronously.
 


### PR DESCRIPTION
This tiny contribution +`[App]` fixes a (based)pyright error. I believe this error is out of place for a project that is so well type-hinted.

```txt
Type of "open_async" is partially unknown
  Type of "open_async" is "(pool: Any | None = None) -> AwaitableContext[Unknown]"
```

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type specificity for the async context manager to provide more accurate type information for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->