### PR TITLE
Add async and sync methods to list jobs by IDs

### DIFF
--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -659,6 +659,31 @@ class JobManager:
         )
         return [jobs_module.Job.from_row(row) for row in rows]
 
+    async def list_jobs_by_ids_async(
+        self, job_ids: Iterable[int]
+    ) -> list[jobs_module.Job]:
+        """
+        List procrastinate jobs matching the provided IDs in a single query.
+
+        Parameters
+        ----------
+        job_ids:
+            Iterable of job IDs to fetch. Missing IDs are ignored and results are
+            ordered by ascending job ID.
+
+        Returns
+        -------
+        :
+        """
+        job_ids = list(dict.fromkeys(job_ids))
+        if not job_ids:
+            return []
+
+        rows = await self.connector.execute_query_all_async(
+            query=sql.queries["list_jobs_by_ids"], job_ids=job_ids
+        )
+        return [jobs_module.Job.from_row(row) for row in rows]
+
     def list_jobs(
         self,
         id: int | None = None,
@@ -681,6 +706,19 @@ class JobManager:
             lock=lock,
             queueing_lock=queueing_lock,
             worker_id=worker_id,
+        )
+        return [jobs_module.Job.from_row(row) for row in rows]
+
+    def list_jobs_by_ids(self, job_ids: Iterable[int]) -> list[jobs_module.Job]:
+        """
+        Sync version of `list_jobs_by_ids_async`.
+        """
+        job_ids = list(dict.fromkeys(job_ids))
+        if not job_ids:
+            return []
+
+        rows = self.connector.get_sync_connector().execute_query_all(
+            query=sql.queries["list_jobs_by_ids"], job_ids=job_ids
         )
         return [jobs_module.Job.from_row(row) for row in rows]
 

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -120,6 +120,24 @@ SELECT id,
    AND (%(worker_id)s::bigint IS NULL OR worker_id = %(worker_id)s)
  ORDER BY id ASC;
 
+-- list_jobs_by_ids --
+-- Get list of jobs filtered by multiple ids
+SELECT id,
+       queue_name,
+       task_name,
+       priority,
+       lock,
+       queueing_lock,
+       args,
+       status,
+       scheduled_at,
+       attempts,
+       abort_requested,
+       worker_id
+  FROM procrastinate_jobs
+ WHERE id = ANY(%(job_ids)s::bigint[])
+ ORDER BY id ASC;
+
 -- list_queues --
 -- Get list of queues and number of jobs per queue
 WITH jobs AS (

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -425,7 +425,11 @@ class InMemoryConnector(connector.BaseAsyncConnector):
 
     async def list_jobs_by_ids_all(self, job_ids: Iterable[int]):
         unique_job_ids = {int(job_id) for job_id in job_ids}
-        return [self.jobs[job_id] for job_id in sorted(unique_job_ids) if job_id in self.jobs]
+        return [
+            self.jobs[job_id]
+            for job_id in sorted(unique_job_ids)
+            if job_id in self.jobs
+        ]
 
     async def list_queues_all(self, **kwargs: Any):
         result: list[dict[str, Any]] = []

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -423,6 +423,10 @@ class InMemoryConnector(connector.BaseAsyncConnector):
                 jobs.append(job)
         return iter(jobs)
 
+    async def list_jobs_by_ids_all(self, job_ids: Iterable[int]):
+        unique_job_ids = {int(job_id) for job_id in job_ids}
+        return [self.jobs[job_id] for job_id in sorted(unique_job_ids) if job_id in self.jobs]
+
     async def list_queues_all(self, **kwargs: Any):
         result: list[dict[str, Any]] = []
         jobs = list(await self.list_jobs_all(**kwargs))

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -781,6 +781,42 @@ async def test_list_jobs(fixture_jobs, kwargs, expected, pg_job_manager):
     ] == expected
 
 
+async def test_list_jobs_by_ids(fixture_jobs, pg_job_manager):
+    result = await pg_job_manager.list_jobs_by_ids_async([4, 999, 2, 2, 1])
+
+    assert [job.id for job in result] == [1, 2, 4]
+
+
+def test_list_jobs_by_ids_sync(sync_psycopg_connector, job_factory):
+    pg_job_manager = manager.JobManager(connector=sync_psycopg_connector)
+    job1 = pg_job_manager.defer_job(
+        job=job_factory(
+            id=None,
+            queue="queue_a",
+            task_name="task_a",
+            task_kwargs={},
+            lock="lock_a",
+            queueing_lock=None,
+        )
+    )
+    job2 = pg_job_manager.defer_job(
+        job=job_factory(
+            id=None,
+            queue="queue_b",
+            task_name="task_b",
+            task_kwargs={},
+            lock="lock_b",
+            queueing_lock=None,
+        )
+    )
+    assert job1.id is not None
+    assert job2.id is not None
+
+    result = pg_job_manager.list_jobs_by_ids([job2.id, 999, job1.id, job1.id])
+
+    assert [job.id for job in result] == [job1.id, job2.id]
+
+
 async def test_list_queues_dict(fixture_jobs, pg_job_manager):
     assert (await pg_job_manager.list_queues_async())[0] == {
         "name": "q1",

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -589,6 +589,38 @@ def test_list_jobs(job_manager, job_factory):
     assert job_manager.list_jobs() == [job]
 
 
+async def test_list_jobs_by_ids_async(job_manager, job_factory):
+    job1 = await job_manager.defer_job_async(job=job_factory(id=None))
+    job2 = await job_manager.defer_job_async(job=job_factory(id=None))
+    job3 = await job_manager.defer_job_async(job=job_factory(id=None))
+
+    result = await job_manager.list_jobs_by_ids_async(
+        [job3.id, 999, job1.id, job1.id, job2.id]
+    )
+
+    assert result == [job1, job2, job3]
+
+
+def test_list_jobs_by_ids(job_manager, job_factory):
+    job1 = job_manager.defer_job(job=job_factory(id=None))
+    job2 = job_manager.defer_job(job=job_factory(id=None))
+    job3 = job_manager.defer_job(job=job_factory(id=None))
+
+    result = job_manager.list_jobs_by_ids([job3.id, 999, job1.id, job1.id, job2.id])
+
+    assert result == [job1, job2, job3]
+
+
+async def test_list_jobs_by_ids_async_empty(job_manager, connector):
+    assert await job_manager.list_jobs_by_ids_async([]) == []
+    assert connector.queries == []
+
+
+def test_list_jobs_by_ids_empty(job_manager, connector):
+    assert job_manager.list_jobs_by_ids([]) == []
+    assert connector.queries == []
+
+
 async def test_list_queues_async(job_manager, job_factory):
     await job_manager.defer_job_async(job=job_factory(queue="foo"))
 


### PR DESCRIPTION
## Summary

Adds public batch job lookup APIs to `JobManager` so application code can fetch many known job ids in one database round-trip.

New APIs:
- `JobManager.list_jobs_by_ids_async(job_ids: Iterable[int])`
- `JobManager.list_jobs_by_ids(job_ids: Iterable[int])`

## Why

Today, the public API only exposes `list_jobs_async(id=...)` / `list_jobs(id=...)` for a single job id. When application code already has many known ids, that forces an N+1 pattern by looping and calling the single-id API repeatedly.

This change adds a dedicated batch lookup API for that use case.

## What changed

- Added a new SQL query for batch lookup by ids
- Added async and sync `JobManager` methods for batch loading jobs
- Kept existing `list_jobs*` single-id behavior unchanged
- Return values remain normal `Job` objects
- Missing ids are ignored naturally
- Empty input returns an empty list without querying
- Results are returned in ascending job id order
- Duplicate input ids do not duplicate returned jobs

## Example

```python
jobs = await app.job_manager.list_jobs_by_ids_async([123, 456, 789])
jobs_by_id = {job.id: job for job in jobs}
```

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve multiple jobs in a single, efficient call (both async and sync). Inputs are deduplicated, original ordering is preserved, and empty input returns an empty list without issuing queries.
* **Tests**
  * Added unit and integration tests verifying deduplication, ordering, handling of missing IDs, and empty-input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->