### PR TITLE
contrib/django: auto-close Django DB connections after task execution

### DIFF
--- a/docs/howto/django/basic_usage.md
+++ b/docs/howto/django/basic_usage.md
@@ -53,6 +53,32 @@ in Django's settings (see {doc}`logs`).
 See {doc}`../basics/command_line` for more details on the CLI.
 If you prefer writing your own scripts, see {doc}`scripts`.
 
+## Database connections
+
+The worker manages Django's database connections around each task the same way
+Django does around an HTTP request: per-thread connections are closed before and
+after every task (sync or async) via `close_old_connections()`. You don't need to
+manage connections in your tasks, and `CONN_MAX_AGE` is respected, so persistent
+connections are reused between tasks rather than force-closed.
+
+Because the connection is only closed at these task boundaries (not in between), a
+connection opened early in a long-running task stays open until the task finishes,
+even across a long stretch of non-database work. If that matters — to free a
+connection slot, or to avoid reusing a connection that may have dropped while
+idle — close it from within the task once you're done with the database for a
+while:
+
+```python
+from django.db import close_old_connections
+
+@app.task
+def long_task():
+    do_early_db_work()
+    close_old_connections()  # release the connection before the long idle stretch
+    do_hours_of_non_db_work()
+    do_late_db_work()  # reconnects fresh
+```
+
 ## Deferring jobs
 
 Defer jobs from your views works as you would expect:

--- a/docs/howto/django/basic_usage.md
+++ b/docs/howto/django/basic_usage.md
@@ -57,9 +57,11 @@ If you prefer writing your own scripts, see {doc}`scripts`.
 
 The worker manages Django's database connections around each task the same way
 Django does around an HTTP request: per-thread connections are closed before and
-after every task (sync or async) via `close_old_connections()`. You don't need to
-manage connections in your tasks, and `CONN_MAX_AGE` is respected, so persistent
-connections are reused between tasks rather than force-closed.
+after every task (sync or async) via `close_old_connections()`, and Django's
+query log (only populated under `DEBUG=True`) is cleared with `reset_queries()`.
+You don't need to manage connections in your tasks, and `CONN_MAX_AGE` is
+respected, so persistent connections are reused between tasks rather than
+force-closed.
 
 Because the connection is only closed at these task boundaries (not in between), a
 connection opened early in a long-running task stays open until the task finishes,

--- a/docs/howto/django/basic_usage.md
+++ b/docs/howto/django/basic_usage.md
@@ -59,16 +59,16 @@ The worker manages Django's database connections around each task the same way
 Django does around an HTTP request: per-thread connections are closed before and
 after every task (sync or async) via `close_old_connections()`, and Django's
 query log (only populated under `DEBUG=True`) is cleared with `reset_queries()`.
-You don't need to manage connections in your tasks, and `CONN_MAX_AGE` is
-respected, so persistent connections are reused between tasks rather than
-force-closed.
+So for an ordinary task you don't have to do anything — the connection it opens is
+cleaned up at the task boundaries, and `CONN_MAX_AGE` is respected, so persistent
+connections are reused between tasks rather than force-closed.
 
-Because the connection is only closed at these task boundaries (not in between), a
-connection opened early in a long-running task stays open until the task finishes,
-even across a long stretch of non-database work. If that matters — to free a
-connection slot, or to avoid reusing a connection that may have dropped while
-idle — close it from within the task once you're done with the database for a
-while:
+The one case this doesn't cover is *within* a single long-running task: the worker
+only closes at task boundaries, so a connection opened early stays open until the
+task finishes, even across a long stretch of non-database work. That holds a
+connection slot for the whole task and risks the idle connection being dropped
+before a later query. If that matters, close it from within the task once you're
+done with the database for a while:
 
 ```python
 from django.db import close_old_connections

--- a/docs/howto/django/tests.md
+++ b/docs/howto/django/tests.md
@@ -78,13 +78,17 @@ def test_my_task():
 :::{note}
 Registering a new task on the django procrastinate app within a test will
 make this task available even after the test has run. You probably want to
-avoid this, for example by creating a new app within each of those tests:
+avoid this, for example by creating a new app within each of those tests. Use
+{py:class}`~procrastinate.contrib.django.DjangoApp` (the same app class the
+contrib uses) so tasks run by a worker still get the automatic connection
+cleanup (see {doc}`basic_usage`) and don't leak connections at test database
+teardown:
 
 ```python
-from procrastinate.contrib.django import app
+from procrastinate.contrib.django import DjangoApp, app
 
 def test_my_task():
-    new_app = procrastinate_app.ProcrastinateApp(app.connector)
+    new_app = DjangoApp(connector=app.connector)
 
     @new_app.task
     def my_task(a, b):

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -100,6 +100,8 @@ Django
 
 .. automodule:: procrastinate.contrib.django
 
+.. autoclass:: procrastinate.contrib.django.DjangoApp
+
 
 SQLAlchemy
 ----------

--- a/procrastinate/contrib/django/__init__.py
+++ b/procrastinate/contrib/django/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from .db_cleanup import DjangoApp
 from .procrastinate_app import app
 from .utils import connector_params
 
 __all__ = [
+    "DjangoApp",
     "app",
     "connector_params",
 ]

--- a/procrastinate/contrib/django/apps.py
+++ b/procrastinate/contrib/django/apps.py
@@ -7,7 +7,7 @@ from django.utils import module_loading
 
 import procrastinate
 
-from . import django_connector, procrastinate_app, settings
+from . import db_cleanup, django_connector, procrastinate_app, settings
 
 
 class ProcrastinateConfig(apps.AppConfig):
@@ -38,7 +38,7 @@ def create_app(blueprint: procrastinate.Blueprint) -> procrastinate.App:
     connector = django_connector.DjangoConnector(
         alias=settings.settings.DATABASE_ALIAS,
     )
-    app = procrastinate.App(
+    app = db_cleanup.DjangoApp(
         connector=connector,
         import_paths=list(get_import_paths()),
         worker_defaults=settings.settings.WORKER_DEFAULTS,

--- a/procrastinate/contrib/django/db_cleanup.py
+++ b/procrastinate/contrib/django/db_cleanup.py
@@ -5,7 +5,7 @@ import inspect
 from typing import TYPE_CHECKING, Any
 
 from asgiref import sync as asgiref_sync
-from django.db import close_old_connections
+from django.db import close_old_connections, reset_queries
 
 from procrastinate import app as app_module
 from procrastinate import blueprints
@@ -18,23 +18,40 @@ if TYPE_CHECKING:
 _WRAPPED_FLAG = "_procrastinate_django_db_cleanup"
 
 
+def _cleanup_before() -> None:
+    # Drop a persistent connection (``CONN_MAX_AGE > 0``) that may have died while
+    # the worker thread was idle between tasks, so the task transparently
+    # reconnects instead of failing on a dead socket.
+    close_old_connections()
+
+
+def _cleanup_after() -> None:
+    # Don't leak the connection past the unit of work...
+    close_old_connections()
+    # ...and clear Django's per-connection query log. It is only populated when
+    # settings.DEBUG is True (and closing the connection does not clear it, since
+    # the log lives on the persistent connection wrapper), so without this a
+    # worker run with DEBUG=True slowly accumulates it. Mirrors what Django does
+    # at request_started; a no-op when DEBUG is False.
+    reset_queries()
+
+
 def wrap_task(task: tasks.Task) -> None:
     """
     Wrap a task's function so that Django's per-thread database connections are
-    closed before and after the task runs.
+    managed around the task, the same way Django manages them around a request.
 
     Procrastinate sync tasks run inside an asgiref ``sync_to_async`` worker-pool
     thread (see ``procrastinate.worker``). Django's connection cache is
     thread-local and the caller owns closing connections in non-request contexts,
     so without this the connection opened by a sync ORM call leaks for the
-    lifetime of the (reused) pool thread. We mirror Django's own request lifecycle
-    (``close_old_connections`` wired to both ``request_started`` and
-    ``request_finished``) by closing around each task:
+    lifetime of the (reused) pool thread. We close around each task:
 
-    - before: drop a persistent connection (``CONN_MAX_AGE > 0``) that may have
-      died while the pool thread was idle between tasks, so the task transparently
-      reconnects instead of failing on a dead socket;
-    - after: don't leak the connection past the unit of work.
+    - before: drop a persistent connection that may have died while the pool
+      thread was idle between tasks, so the task transparently reconnects instead
+      of failing on a dead socket;
+    - after: don't leak the connection past the unit of work, and clear the
+      (DEBUG-only) query log.
 
     ``close_old_connections`` respects ``CONN_MAX_AGE``: a healthy persistent
     connection is kept, while with the default ``CONN_MAX_AGE = 0`` every
@@ -48,20 +65,19 @@ def wrap_task(task: tasks.Task) -> None:
         return
 
     if inspect.iscoroutinefunction(func):
+        # The task runs in the event-loop thread. Django's connection.close() is
+        # @async_unsafe, so run the cleanup in Django's thread-sensitive context
+        # (where the async ORM ran its sync work) via sync_to_async.
+        before = asgiref_sync.sync_to_async(_cleanup_before, thread_sensitive=True)
+        after = asgiref_sync.sync_to_async(_cleanup_after, thread_sensitive=True)
 
         @functools.wraps(func)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-            # The task runs in the event-loop thread. Django's connection.close()
-            # is @async_unsafe, so we close in Django's thread-sensitive context
-            # (where the async ORM ran its sync work) via sync_to_async.
-            aclose = asgiref_sync.sync_to_async(
-                close_old_connections, thread_sensitive=True
-            )
-            await aclose()
+            await before()
             try:
                 return await func(*args, **kwargs)
             finally:
-                await aclose()
+                await after()
 
         wrapper = async_wrapper
 
@@ -72,14 +88,14 @@ def wrap_task(task: tasks.Task) -> None:
             # Runs in the worker's sync_to_async pool thread, the same thread
             # Django opened its per-thread connection in.
             # Note: for the rare sync function that returns an awaitable without
-            # being a coroutine function (awaited later by the worker), the final
-            # close happens after the sync portion returns the awaitable, not
+            # being a coroutine function (awaited later by the worker), the
+            # cleanup happens after the sync portion returns the awaitable, not
             # after it is awaited. That edge case is out of scope here.
-            close_old_connections()
+            _cleanup_before()
             try:
                 return func(*args, **kwargs)
             finally:
-                close_old_connections()
+                _cleanup_after()
 
         wrapper = sync_wrapper
 

--- a/procrastinate/contrib/django/db_cleanup.py
+++ b/procrastinate/contrib/django/db_cleanup.py
@@ -105,8 +105,18 @@ def wrap_task(task: tasks.Task) -> None:
 
 class DjangoApp(app_module.App):
     """
-    A :class:`procrastinate.App` that automatically closes Django's per-thread
+    A :class:`procrastinate.App` that automatically manages Django's per-thread
     database connections around each task execution (see :func:`wrap_task`).
+
+    This is the app the Django contrib uses (``procrastinate.contrib.django.app``).
+    It is also the app you want when building a throwaway app in a test (e.g. to
+    avoid leaving a task registered on the global app), so that tasks run by a
+    worker get the same connection cleanup and don't leak connections at test
+    database teardown::
+
+        from procrastinate.contrib.django import DjangoApp, app
+
+        new_app = DjangoApp(connector=app.connector)
 
     Every task reaches the registry through ``_register_task`` (the ``@app.task``
     decorator) or ``add_tasks_from`` (builtin tasks, the contrib ``FutureApp``

--- a/procrastinate/contrib/django/db_cleanup.py
+++ b/procrastinate/contrib/django/db_cleanup.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import TYPE_CHECKING, Any
+
+from asgiref import sync as asgiref_sync
+from django.db import close_old_connections
+
+from procrastinate import app as app_module
+from procrastinate import blueprints
+
+if TYPE_CHECKING:
+    from procrastinate import tasks
+
+# Sentinel attribute set on a wrapped task function so wrapping is idempotent
+# (a task may be registered under several names/aliases or merged more than once).
+_WRAPPED_FLAG = "_procrastinate_django_db_cleanup"
+
+
+def wrap_task(task: tasks.Task) -> None:
+    """
+    Wrap a task's function so that Django's per-thread database connections are
+    closed before and after the task runs.
+
+    Procrastinate sync tasks run inside an asgiref ``sync_to_async`` worker-pool
+    thread (see ``procrastinate.worker``). Django's connection cache is
+    thread-local and the caller owns closing connections in non-request contexts,
+    so without this the connection opened by a sync ORM call leaks for the
+    lifetime of the (reused) pool thread. We mirror Django's own request lifecycle
+    (``close_old_connections`` wired to both ``request_started`` and
+    ``request_finished``) by closing around each task:
+
+    - before: drop a persistent connection (``CONN_MAX_AGE > 0``) that may have
+      died while the pool thread was idle between tasks, so the task transparently
+      reconnects instead of failing on a dead socket;
+    - after: don't leak the connection past the unit of work.
+
+    ``close_old_connections`` respects ``CONN_MAX_AGE``: a healthy persistent
+    connection is kept, while with the default ``CONN_MAX_AGE = 0`` every
+    connection is closed.
+
+    The wrapper preserves the sync/async nature of the original function so the
+    worker's ``inspect.iscoroutinefunction`` detection keeps working.
+    """
+    func = task.func
+    if getattr(func, _WRAPPED_FLAG, False):
+        return
+
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            # The task runs in the event-loop thread. Django's connection.close()
+            # is @async_unsafe, so we close in Django's thread-sensitive context
+            # (where the async ORM ran its sync work) via sync_to_async.
+            aclose = asgiref_sync.sync_to_async(
+                close_old_connections, thread_sensitive=True
+            )
+            await aclose()
+            try:
+                return await func(*args, **kwargs)
+            finally:
+                await aclose()
+
+        wrapper = async_wrapper
+
+    else:
+
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Runs in the worker's sync_to_async pool thread, the same thread
+            # Django opened its per-thread connection in.
+            # Note: for the rare sync function that returns an awaitable without
+            # being a coroutine function (awaited later by the worker), the final
+            # close happens after the sync portion returns the awaitable, not
+            # after it is awaited. That edge case is out of scope here.
+            close_old_connections()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                close_old_connections()
+
+        wrapper = sync_wrapper
+
+    setattr(wrapper, _WRAPPED_FLAG, True)
+    task.func = wrapper
+
+
+class DjangoApp(app_module.App):
+    """
+    A :class:`procrastinate.App` that automatically closes Django's per-thread
+    database connections around each task execution (see :func:`wrap_task`).
+
+    Every task reaches the registry through ``_register_task`` (the ``@app.task``
+    decorator) or ``add_tasks_from`` (builtin tasks, the contrib ``FutureApp``
+    blueprint, and any ``on_app_ready`` blueprints), so wrapping in both covers
+    all registration paths.
+    """
+
+    def _register_task(self, task: tasks.Task) -> None:
+        super()._register_task(task)
+        wrap_task(task)
+
+    def add_tasks_from(
+        self, blueprint: blueprints.Blueprint, *, namespace: str
+    ) -> None:
+        super().add_tasks_from(blueprint, namespace=namespace)
+        # After the merge, blueprint.tasks holds the (namespaced) task objects.
+        for task in blueprint.tasks.values():
+            wrap_task(task)

--- a/tests/integration/contrib/django/test_db_cleanup.py
+++ b/tests/integration/contrib/django/test_db_cleanup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 from django.db import connection
@@ -22,6 +23,23 @@ def count_other_sessions() -> int:
             "WHERE datname = current_database() AND pid <> pg_backend_pid()"
         )
         return cursor.fetchone()[0]
+
+
+def assert_no_leaked_session(before: int, timeout: float = 10.0) -> None:
+    """
+    Assert the worker run didn't leak a session, tolerating transient sessions.
+
+    The worker uses its own psycopg connection pool (``min_size=4`` + listen/notify)
+    whose connections are torn down asynchronously when the worker stops, so right
+    after ``run_worker_once()`` the count can still be briefly elevated. A *real*
+    per-thread Django ORM leak, by contrast, never goes away (the asgiref worker
+    thread persists holding it). So poll until the transient pool sessions drain:
+    a leak never settles and the assertion fails at the deadline.
+    """
+    deadline = time.monotonic() + timeout
+    while count_other_sessions() > before and time.monotonic() < deadline:
+        time.sleep(0.1)
+    assert count_other_sessions() <= before
 
 
 def run_worker_once() -> None:
@@ -61,7 +79,7 @@ def test_sync_task_does_not_leak_db_connections():
     # too brittle because this database is shared across the test session.
     before = count_other_sessions()
     run_worker_once()
-    assert count_other_sessions() <= before
+    assert_no_leaked_session(before)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -77,4 +95,4 @@ def test_async_task_does_not_leak_db_connections():
 
     before = count_other_sessions()
     run_worker_once()
-    assert count_other_sessions() <= before
+    assert_no_leaked_session(before)

--- a/tests/integration/contrib/django/test_db_cleanup.py
+++ b/tests/integration/contrib/django/test_db_cleanup.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from django.db import connection
+
+import procrastinate.contrib.django
+from procrastinate.contrib.django import models
+
+
+def count_other_sessions() -> int:
+    """
+    Number of sessions on the test database other than the test's own
+    connection. The connection leaked by a worker thread (a different thread than
+    the test) is invisible to Django's thread-local cache but shows up here,
+    because pg_stat_activity is server-side and global.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+        )
+        return cursor.fetchone()[0]
+
+
+def run_worker_once() -> None:
+    app = procrastinate.contrib.django.app
+
+    async def run() -> None:
+        # The Django connector can't listen/notify, so the worker uses a separate
+        # async connector whose own pool is closed when open_async() exits.
+        with app.replace_connector(app.connector.get_worker_connector()) as worker_app:
+            async with worker_app.open_async():
+                await worker_app.run_worker_async(
+                    wait=False,
+                    install_signal_handlers=False,
+                    listen_notify=False,
+                )
+
+    asyncio.run(run())
+
+
+# transaction=True so the deferred job is actually committed and visible to the
+# worker's separate connection (a transaction-rollback test would hide it and the
+# worker would process nothing, passing vacuously).
+@pytest.mark.django_db(transaction=True)
+def test_sync_task_does_not_leak_db_connections():
+    app = procrastinate.contrib.django.app
+
+    @app.task(name="test_db_cleanup_sync_task")
+    def sync_task():
+        # Sync ORM call: opens a per-thread Django connection in the worker thread.
+        list(models.ProcrastinateJob.objects.all())
+
+    sync_task.defer()
+
+    # Assert the worker run doesn't *increase* the session count: a leaked
+    # connection shows up as a net +1, while sessions left by other tests (or
+    # cleaned up by our own before/after close) cancel out. An absolute count is
+    # too brittle because this database is shared across the test session.
+    before = count_other_sessions()
+    run_worker_once()
+    assert count_other_sessions() <= before
+
+
+@pytest.mark.django_db(transaction=True)
+def test_async_task_does_not_leak_db_connections():
+    app = procrastinate.contrib.django.app
+
+    @app.task(name="test_db_cleanup_async_task")
+    async def async_task():
+        # Async ORM call.
+        await models.ProcrastinateJob.objects.acount()
+
+    async_task.defer()
+
+    before = count_other_sessions()
+    run_worker_once()
+    assert count_other_sessions() <= before

--- a/tests/unit/contrib/django/test_db_cleanup.py
+++ b/tests/unit/contrib/django/test_db_cleanup.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from procrastinate import blueprints, testing
+from procrastinate.contrib.django import db_cleanup
+from procrastinate.tasks import Task
+
+
+def make_task(func, name="task"):
+    return Task(func=func, blueprint=blueprints.Blueprint(), queue="default", name=name)
+
+
+def test_wrap_task_sync_closes_before_and_after(mocker):
+    events = []
+    mocker.patch.object(
+        db_cleanup,
+        "close_old_connections",
+        side_effect=lambda: events.append("close"),
+    )
+    task = make_task(lambda: events.append("run"))
+
+    db_cleanup.wrap_task(task)
+    task.func()
+
+    assert events == ["close", "run", "close"]
+
+
+def test_wrap_task_sync_closes_even_on_error(mocker):
+    close = mocker.patch.object(db_cleanup, "close_old_connections")
+
+    def boom():
+        raise ValueError("boom")
+
+    task = make_task(boom)
+    db_cleanup.wrap_task(task)
+
+    with pytest.raises(ValueError):
+        task.func()
+
+    assert close.call_count == 2
+
+
+async def test_wrap_task_async_closes_before_and_after(mocker):
+    events = []
+    mocker.patch.object(
+        db_cleanup,
+        "close_old_connections",
+        side_effect=lambda: events.append("close"),
+    )
+
+    async def coro():
+        events.append("run")
+
+    task = make_task(coro)
+    db_cleanup.wrap_task(task)
+    await task.func()
+
+    assert events == ["close", "run", "close"]
+
+
+def test_wrap_task_preserves_sync_or_async_nature():
+    def sync_func():
+        pass
+
+    async def async_func():
+        pass
+
+    sync_task = make_task(sync_func)
+    async_task = make_task(async_func)
+
+    db_cleanup.wrap_task(sync_task)
+    db_cleanup.wrap_task(async_task)
+
+    # The worker branches on inspect.iscoroutinefunction(task.func), so wrapping
+    # must not change it.
+    assert inspect.iscoroutinefunction(sync_task.func) is False
+    assert inspect.iscoroutinefunction(async_task.func) is True
+
+
+def test_wrap_task_is_idempotent():
+    task = make_task(lambda: None)
+
+    db_cleanup.wrap_task(task)
+    wrapped_once = task.func
+    db_cleanup.wrap_task(task)
+
+    assert task.func is wrapped_once
+
+
+def test_django_app_wraps_tasks_from_both_registration_paths():
+    app = db_cleanup.DjangoApp(connector=testing.InMemoryConnector())
+
+    @app.task(name="decorated")
+    def decorated():
+        pass
+
+    bp = blueprints.Blueprint()
+
+    @bp.task(name="from_blueprint")
+    def from_blueprint():
+        pass
+
+    app.add_tasks_from(bp, namespace="ns")
+
+    flag = db_cleanup._WRAPPED_FLAG
+    assert getattr(app.tasks["decorated"].func, flag, False) is True
+    assert getattr(app.tasks["ns:from_blueprint"].func, flag, False) is True
+    # Builtin tasks (registered via add_tasks_from in App.__init__) too.
+    assert all(getattr(t.func, flag, False) for t in app.tasks.values())

--- a/tests/unit/contrib/django/test_db_cleanup.py
+++ b/tests/unit/contrib/django/test_db_cleanup.py
@@ -20,16 +20,21 @@ def test_wrap_task_sync_closes_before_and_after(mocker):
         "close_old_connections",
         side_effect=lambda: events.append("close"),
     )
+    # reset_queries clears the (DEBUG-only) query log and runs only after the task.
+    mocker.patch.object(
+        db_cleanup, "reset_queries", side_effect=lambda: events.append("reset")
+    )
     task = make_task(lambda: events.append("run"))
 
     db_cleanup.wrap_task(task)
     task.func()
 
-    assert events == ["close", "run", "close"]
+    assert events == ["close", "run", "close", "reset"]
 
 
-def test_wrap_task_sync_closes_even_on_error(mocker):
+def test_wrap_task_sync_cleans_up_even_on_error(mocker):
     close = mocker.patch.object(db_cleanup, "close_old_connections")
+    reset = mocker.patch.object(db_cleanup, "reset_queries")
 
     def boom():
         raise ValueError("boom")
@@ -40,7 +45,9 @@ def test_wrap_task_sync_closes_even_on_error(mocker):
     with pytest.raises(ValueError):
         task.func()
 
+    # before + after close, and the after-task reset, all still happen.
     assert close.call_count == 2
+    assert reset.call_count == 1
 
 
 async def test_wrap_task_async_closes_before_and_after(mocker):
@@ -50,6 +57,9 @@ async def test_wrap_task_async_closes_before_and_after(mocker):
         "close_old_connections",
         side_effect=lambda: events.append("close"),
     )
+    mocker.patch.object(
+        db_cleanup, "reset_queries", side_effect=lambda: events.append("reset")
+    )
 
     async def coro():
         events.append("run")
@@ -58,7 +68,7 @@ async def test_wrap_task_async_closes_before_and_after(mocker):
     db_cleanup.wrap_task(task)
     await task.func()
 
-    assert events == ["close", "run", "close"]
+    assert events == ["close", "run", "close", "reset"]
 
 
 def test_wrap_task_preserves_sync_or_async_nature():

--- a/tests/unit/contrib/django/test_db_cleanup.py
+++ b/tests/unit/contrib/django/test_db_cleanup.py
@@ -120,3 +120,19 @@ def test_django_app_wraps_tasks_from_both_registration_paths():
     assert getattr(app.tasks["ns:from_blueprint"].func, flag, False) is True
     # Builtin tasks (registered via add_tasks_from in App.__init__) too.
     assert all(getattr(t.func, flag, False) for t in app.tasks.values())
+
+
+def test_django_app_is_publicly_exported():
+    # Users build a throwaway DjangoApp in tests (see howto/django/tests); it must
+    # be importable from the package and wrap tasks so those tests don't leak.
+    from procrastinate.contrib.django import DjangoApp
+
+    assert DjangoApp is db_cleanup.DjangoApp
+
+    app = DjangoApp(connector=testing.InMemoryConnector())
+
+    @app.task(name="user_task")
+    def user_task():
+        pass
+
+    assert getattr(app.tasks["user_task"].func, db_cleanup._WRAPPED_FLAG, False) is True


### PR DESCRIPTION
## What

When a Procrastinate task uses the Django ORM, the per-thread Django DB connection opened to run it was never closed. In long-running workers this accumulates connections over time; in tests it surfaces at teardown as `database "..." is being accessed by other users`.

The Django contrib now manages Django's per-thread database connections around each task the same way Django does around an HTTP request — `close_old_connections()` **before and after** every task (mirroring Django's `request_started`/`request_finished` wiring, and what Celery and Channels do), plus `reset_queries()` after each task to clear Django's per-connection query log. This covers **both sync and async** tasks:

- **sync tasks** clean up in the asgiref `sync_to_async` worker-pool thread (where the leaked connection lives);
- **async tasks** clean up via `sync_to_async(thread_sensitive=True)`, since Django's `connection.close()` is `@async_unsafe` and must not run on the event loop.

`CONN_MAX_AGE` is respected — healthy persistent connections are kept, only obsolete/unusable ones are dropped. `reset_queries()` is a no-op unless `DEBUG=True`, but closing the connection does not clear the query log (it lives on the persistent connection wrapper), so a long-running worker with `DEBUG=True` would otherwise accumulate it.

## How

- New `procrastinate/contrib/django/db_cleanup.py`:
  - `wrap_task(task)` — idempotent, async/sync-aware wrapper that runs the cleanup around the task. Preserves `inspect.iscoroutinefunction(task.func)` so the worker's sync/async branching keeps working.
  - `DjangoApp(procrastinate.App)` — overrides `_register_task` and `add_tasks_from`, the two registration chokepoints, so every task (decorator, blueprints, `import_paths`/autodiscover, builtin, periodic) is wrapped.
- `apps.py` `create_app` instantiates `DjangoApp` instead of `procrastinate.App`.
- `DjangoApp` is re-exported as `procrastinate.contrib.django.DjangoApp` (public) so a test can build a throwaway app that gets the same cleanup; the Django test howto's broken `ProcrastinateApp(...)` snippet is fixed to use it.
- Docs: a "Database connections" section in `howto/django/basic_usage.md`, including how a very long task can release its connection mid-run.

The cleanup runs only at task boundaries (not mid-task); the docs note how a long-running task can call `close_old_connections()` itself if it idles on the DB for a long stretch.

## Tests

- **Unit** (`tests/unit/contrib/django/test_db_cleanup.py`): cleanup before+after and on error, `reset_queries` runs once after-only, async path, sync/async-ness preserved, idempotency, both-registration-paths coverage.
- **Integration** (`tests/integration/contrib/django/test_db_cleanup.py`): defer a sync/async ORM task, run the worker once, assert no net `pg_stat_activity` session increase. Uses `transaction=True` so the worker's separate connection actually sees the committed job. Verified red-first — both tests fail (leaked sessions, incl. the exact teardown error) without the wrapper.

## Related issues

- **Closes #1551** — the test-teardown `database "..." is being accessed by other users` leak (supersedes the closed #1106, which was entirely about this warning in Django integration tests). The Django test howto's per-test "throwaway app" pattern is also fixed and made leak-free via the public `DjangoApp`.
- **Likely fixes #1316** ("Django memory leak?") — this is the in-contrib version of the Channels-style `close_old_connections()` wrapper that resolved it downstream, plus `reset_queries()` for the `DEBUG=True` query-log growth. Left as "Closes"-free since memory-leak confirmation needs the reporter's environment.
- **Partially addresses #1134** ("OperationalError: the connection is closed") — the before-task close drops a stale connection left by a previous task, so the next task reconnects fresh; a connection that dies *mid-way through a single long task* is out of scope (see the long-task note in the docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Database connections" how-to and updated test guidance and API docs for the Django integration.

* **New Features**
  * Django integration now auto-wraps registered tasks to manage DB connections around task execution and exposes a Django-specific app class.

* **Bug Fixes**
  * Ensures DB connections are closed/reset for both sync and async tasks to prevent leaks.

* **Tests**
  * Added unit and integration tests verifying no leaked DB sessions for sync and async tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
