### PR TITLE
Feature: variable worker concurrency

### DIFF
--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -343,7 +343,9 @@ class App(blueprints.Blueprint):
 
         asyncio.run(f())
 
-    async def run_worker_async_background(self, **kwargs: Unpack[WorkerOptions]) -> worker.Worker:
+    async def run_worker_async_background(
+        self, **kwargs: Unpack[WorkerOptions]
+    ) -> worker.Worker:
         """
         Run a worker as a background asyncio task.
 

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -26,6 +26,7 @@ class WorkerOptions(TypedDict):
     queues: NotRequired[Iterable[str]]
     name: NotRequired[str]
     concurrency: NotRequired[int]
+    buffer_concurrency: NotRequired[int]
     wait: NotRequired[bool]
     fetch_job_polling_interval: NotRequired[float]
     abort_job_polling_interval: NotRequired[float]
@@ -341,6 +342,41 @@ class App(blueprints.Blueprint):
                 await self.run_worker_async(**kwargs)
 
         asyncio.run(f())
+
+    async def run_worker_async_background(self, **kwargs: Unpack[WorkerOptions]) -> worker.Worker:
+        """
+        Run a worker as a background asyncio task.
+
+        Returns the worker instance immediately, allowing concurrency to be
+        adjusted at runtime via ``worker.set_concurrency()``.
+
+        Parameters
+        ----------
+        buffer_concurrency :
+            Number of buffered semaphore slots for future scaling.
+            Total semaphore capacity will be concurrency + buffer_concurrency.
+        install_signal_handlers :
+            Defaults to ``False`` for this method since the worker
+            runs as a task inside a larger application.
+
+        Returns
+        -------
+        Worker
+            The worker instance. Call ``worker.stop()`` for graceful shutdown.
+            The worker runs as ``worker.run_task`` which you can await or cancel.
+        """
+        self.perform_import_paths()
+
+        # Default to no signal handlers for embedded worker
+        if "install_signal_handlers" not in kwargs:
+            kwargs["install_signal_handlers"] = False
+
+        worker = self._worker(**kwargs)
+        worker.run_task = asyncio.create_task(
+            worker.run(),
+            name=worker.worker_name,
+        )
+        return worker
 
     async def check_connection_async(self) -> bool:
         return await self.job_manager.check_connection_async()

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -52,6 +52,14 @@ class Worker:
         self.app = app
         self.queues = queues
         self.worker_name = name
+        if concurrency < 0 or buffer_concurrency < 0:
+            raise ValueError(
+                "concurrency and buffer_concurrency must be non-negative"
+            )
+        if concurrency + buffer_concurrency <= 0:
+            raise ValueError(
+                "concurrency + buffer_concurrency must be greater than 0"
+            )
         self.concurrency = concurrency
         self.buffer_concurrency = buffer_concurrency
         self.total_capacity = concurrency + buffer_concurrency

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -149,6 +149,21 @@ class Worker:
 
         self.buffer_concurrency = new_buffer
 
+    @property
+    def running_jobs_count(self) -> int:
+        """Number of jobs currently being processed."""
+        return len(self._running_jobs)
+
+    @property
+    def spare_concurrency(self) -> int:
+        """Number of active concurrency slots currently free.
+
+        Returns 0 when the worker is saturated (all slots occupied).
+        A positive value means the worker could process more jobs right now
+        if they were available — i.e. concurrency is NOT the bottleneck.
+        """
+        return max(0, self.concurrency - len(self._running_jobs))
+
     async def _periodic_deferrer(self):
         deferrer = periodic.PeriodicDeferrer(
             registry=self.app.periodic_registry,

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -37,6 +37,7 @@ class Worker:
         queues: Iterable[str] | None = None,
         name: str | None = WORKER_NAME,
         concurrency: int = WORKER_CONCURRENCY,
+        buffer_concurrency: int = 0,
         wait: bool = True,
         fetch_job_polling_interval: float = FETCH_JOB_POLLING_INTERVAL,
         abort_job_polling_interval: float = ABORT_JOB_POLLING_INTERVAL,
@@ -52,6 +53,9 @@ class Worker:
         self.queues = queues
         self.worker_name = name
         self.concurrency = concurrency
+        self.buffer_concurrency = buffer_concurrency
+        self.total_capacity = concurrency + buffer_concurrency
+        self._held_buffer_slots = 0
         self.wait = wait
         self.fetch_job_polling_interval = fetch_job_polling_interval
         self.abort_job_polling_interval = abort_job_polling_interval
@@ -93,6 +97,57 @@ class Worker:
         )
 
         self._stop_event.set()
+
+    def set_concurrency(self, new_concurrency: int) -> None:
+        """
+        Adjust the active concurrency at runtime.
+
+        Parameters
+        ----------
+        new_concurrency :
+            New concurrency level. Must be between 0 and total_capacity.
+
+        Notes
+        -----
+        This method is not thread-safe. Call from a single control coroutine
+        to avoid race conditions with the worker's internal state.
+        """
+        if new_concurrency == self.concurrency:
+            return
+
+        if new_concurrency < 0 or new_concurrency > self.total_capacity:
+            raise ValueError(
+                f"Concurrency must be between 0 and {self.total_capacity}"
+            )
+
+        old_concurrency = self.concurrency
+        old_buffer = self.buffer_concurrency
+        self.concurrency = new_concurrency
+        new_buffer = self.total_capacity - new_concurrency
+
+        if new_concurrency > old_concurrency:
+            # Scale up: release buffer slots one at a time, decrementing counter.
+            # Guard against releasing more slots than actually held.
+            # If set_concurrency is called before _run_loop, _held_buffer_slots is 0,
+            # so slots_to_release becomes 0 and the loop below never runs.
+            # This also avoids releasing on the parent-init semaphore (capacity=concurrency)
+            # before _run_loop replaces it with the correct one (capacity=total_capacity).
+            slots_to_release = min(old_buffer - new_buffer, self._held_buffer_slots)
+            for _ in range(slots_to_release):
+                self._job_semaphore.release()
+                self._held_buffer_slots -= 1
+        elif new_concurrency < old_concurrency:
+            # Scale down: no immediate action needed.
+            # The fetch loop will naturally hold more slots as buffer
+            # on the next acquisitions (since _held_buffer_slots < new_buffer).
+            pass
+
+        self.logger.info(
+            f"Concurrency adjusted: {old_concurrency} -> {new_concurrency} "
+            f"(buffer: {old_buffer} -> {new_buffer})"
+        )
+
+        self.buffer_concurrency = new_buffer
 
     async def _periodic_deferrer(self):
         deferrer = periodic.PeriodicDeferrer(
@@ -327,19 +382,27 @@ class Worker:
         while not self._stop_event.is_set():
             acquire_sem_task = asyncio.create_task(self._job_semaphore.acquire())
             job = None
+            should_release = True
             try:
                 await utils.wait_any(acquire_sem_task, self._stop_event.wait())
                 if self._stop_event.is_set():
                     break
+
+                # Check if this slot should be held as buffer
+                if self._held_buffer_slots < self.buffer_concurrency:
+                    self._held_buffer_slots += 1
+                    should_release = False
+                    continue
 
                 assert self.worker_id is not None
                 job = await self.app.job_manager.fetch_job(
                     queues=self.queues, worker_id=self.worker_id
                 )
             finally:
-                if (not job or self._stop_event.is_set()) and acquire_sem_task.done():
-                    self._job_semaphore.release()
-                self._new_job_event.clear()
+                if should_release:
+                    if (not job or self._stop_event.is_set()) and acquire_sem_task.done():
+                        self._job_semaphore.release()
+                    self._new_job_event.clear()
 
             if not job:
                 break
@@ -592,7 +655,7 @@ class Worker:
         self._new_job_event.clear()
         self._stop_event.clear()
         self._running_jobs = {}
-        self._job_semaphore = asyncio.Semaphore(self.concurrency)
+        self._job_semaphore = asyncio.Semaphore(self.total_capacity)
         side_tasks = self._start_side_tasks()
         side_tasks_monitor = asyncio.create_task(
             self._monitor_side_tasks(side_tasks), name="side_tasks_monitor"
@@ -606,6 +669,12 @@ class Worker:
 
         try:
             with context:
+                # Hold initial buffer slots before first fetch
+                self._held_buffer_slots = 0
+                for _ in range(self.buffer_concurrency):
+                    await self._job_semaphore.acquire()
+                    self._held_buffer_slots += 1
+
                 await self._fetch_and_process_jobs()
                 if not self.wait:
                     self.logger.info(
@@ -628,6 +697,11 @@ class Worker:
                     )
                     await self._fetch_and_process_jobs()
         finally:
+            # Release buffer slots on shutdown
+            for _ in range(self._held_buffer_slots):
+                self._job_semaphore.release()
+                self._held_buffer_slots -= 1
+
             if not side_tasks_monitor.done():
                 side_tasks_monitor.cancel()
             await self._shutdown(side_tasks=side_tasks)

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -53,13 +53,9 @@ class Worker:
         self.queues = queues
         self.worker_name = name
         if concurrency < 0 or buffer_concurrency < 0:
-            raise ValueError(
-                "concurrency and buffer_concurrency must be non-negative"
-            )
+            raise ValueError("concurrency and buffer_concurrency must be non-negative")
         if concurrency + buffer_concurrency <= 0:
-            raise ValueError(
-                "concurrency + buffer_concurrency must be greater than 0"
-            )
+            raise ValueError("concurrency + buffer_concurrency must be greater than 0")
         self.concurrency = concurrency
         self.buffer_concurrency = buffer_concurrency
         self.total_capacity = concurrency + buffer_concurrency
@@ -124,9 +120,7 @@ class Worker:
             return
 
         if new_concurrency < 0 or new_concurrency > self.total_capacity:
-            raise ValueError(
-                f"Concurrency must be between 0 and {self.total_capacity}"
-            )
+            raise ValueError(f"Concurrency must be between 0 and {self.total_capacity}")
 
         old_concurrency = self.concurrency
         old_buffer = self.buffer_concurrency
@@ -423,7 +417,9 @@ class Worker:
                 )
             finally:
                 if should_release:
-                    if (not job or self._stop_event.is_set()) and acquire_sem_task.done():
+                    if (
+                        not job or self._stop_event.is_set()
+                    ) and acquire_sem_task.done():
                         self._job_semaphore.release()
                     self._new_job_event.clear()
 


### PR DESCRIPTION
For initial discussion; happy to sort documentation etc if you're happy with this route. I'm developing on Windows so a lot of tests fail on main at the moment; I'll have a look at spinning up WSL to run tests if this approach is OK. It seems to be working fine for me.

Works by allocating a larger semaphore (=concurrency plus buffer); you can then vary concurrency from zero to initial concurrency+buffer.
On buffer=0 should behave the same as the original worker.
Added app.run_worker_async_background() which returns the worker so its concurrency can be adjusted.

Related: ticket #1552

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [X] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional buffer concurrency to reserve part of worker capacity for pre-fetch buffering.
  * Workers can be started as embedded background asyncio tasks and returned immediately for later control.
  * Runtime adjustment of active concurrency without restart.
  * New readouts for running job count and spare processing capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->