### PR TITLE
feat: add external connection support for job cancellation and status

### DIFF
--- a/docs/howto/production/external_connection.md
+++ b/docs/howto/production/external_connection.md
@@ -80,6 +80,8 @@ your own tables when cancelling a job and want both changes to commit (or roll b
 together:
 
 ```python
+job_id = 33
+
 async with await psycopg.AsyncConnection.connect("...") as conn:
     await conn.execute("UPDATE orders SET state = 'cancelled' WHERE id = %s", [42])
     await app.job_manager.cancel_job_by_id_async(job_id, connection=conn)

--- a/docs/howto/production/external_connection.md
+++ b/docs/howto/production/external_connection.md
@@ -2,7 +2,8 @@
 
 Procrastinate supports deferring jobs on an externally-managed database connection.
 This lets you insert the job within the same transaction as your own database
-operations, enabling patterns like the **transactional outbox**.
+operations, enabling patterns like the **transactional outbox**. Cancelling a job
+and reading its status can run on an external connection too.
 
 ## When to use this
 
@@ -71,6 +72,20 @@ with connector.engine.connect() as conn:
     conn.commit()
 ```
 
+## Cancelling jobs and reading status
+
+`cancel_job_by_id` / `cancel_job_by_id_async` and `get_job_status` /
+`get_job_status_async` accept the same `connection` argument. Useful if you update
+your own tables when cancelling a job and want both changes to commit (or roll back)
+together:
+
+```python
+async with await psycopg.AsyncConnection.connect("...") as conn:
+    await conn.execute("UPDATE orders SET state = 'cancelled' WHERE id = %s", [42])
+    await app.job_manager.cancel_job_by_id_async(job_id, connection=conn)
+    await conn.commit()  # the order update and the cancellation commit together
+```
+
 ## Supported connectors
 
 - `SyncPsycopgConnector` — pass a `psycopg.Connection`
@@ -82,7 +97,9 @@ Other connectors will raise a `ConnectorException` if `connection` is provided.
 ## Important notes
 
 - **NOTIFY is delayed**: The database NOTIFY that wakes workers fires when you
-  commit. This is expected and acceptable.
+  commit. This is expected and acceptable. The same applies when cancelling a
+  running job with `abort=True`: the worker only sees the abort request once you
+  commit.
 - **Error handling**: Errors from the job INSERT (e.g. queueing lock violations)
   are wrapped as usual via procrastinate's exception hierarchy, but they may abort
   your transaction. Use savepoints if you need to isolate the defer from the rest

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -62,6 +62,20 @@ class BaseConnector:
     ) -> list[dict[str, Any]]:
         raise exceptions.SyncConnectorConfigurationError
 
+    def execute_query_one_with_connection(
+        self, connection: Any, query: LiteralString, **arguments: Any
+    ) -> dict[str, Any]:
+        raise exceptions.ConnectorException(
+            f"{type(self).__name__} does not support external connections"
+        )
+
+    async def execute_query_one_async_with_connection(
+        self, connection: Any, query: LiteralString, **arguments: Any
+    ) -> dict[str, Any]:
+        raise exceptions.ConnectorException(
+            f"{type(self).__name__} does not support external connections"
+        )
+
     def execute_query_all_with_connection(
         self, connection: Any, query: LiteralString, **arguments: Any
     ) -> list[dict[str, Any]]:
@@ -116,6 +130,16 @@ class BaseAsyncConnector(BaseConnector):
         self, query: LiteralString, **arguments: Any
     ) -> list[dict[str, Any]]:
         return utils.async_to_sync(self.execute_query_all_async, query, **arguments)
+
+    def execute_query_one_with_connection(
+        self, connection: Any, query: LiteralString, **arguments: Any
+    ) -> dict[str, Any]:
+        return utils.async_to_sync(
+            self.execute_query_one_async_with_connection,
+            connection,
+            query,
+            **arguments,
+        )
 
     def execute_query_all_with_connection(
         self, connection: Any, query: LiteralString, **arguments: Any

--- a/procrastinate/contrib/sqlalchemy/psycopg2_connector.py
+++ b/procrastinate/contrib/sqlalchemy/psycopg2_connector.py
@@ -194,6 +194,19 @@ class SQLAlchemyPsycopg2Connector(connector.BaseConnector):
             return mapping.all()  # pyright: ignore[reportReturnType]
 
     @wrap_exceptions()
+    def execute_query_one_with_connection(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        connection: sqlalchemy.engine.Connection,
+        query: str,
+        **arguments: Any,
+    ) -> Mapping[str, Any]:
+        cursor_result = connection.exec_driver_sql(
+            PERCENT_PATTERN.sub("%%", query), self._wrap_json(arguments)
+        )
+        mapping = cursor_result.mappings()
+        return mapping.fetchone()  # pyright: ignore[reportReturnType]
+
+    @wrap_exceptions()
     def execute_query_all_with_connection(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         connection: sqlalchemy.engine.Connection,

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -348,7 +348,11 @@ class JobManager:
         )
 
     def cancel_job_by_id(
-        self, job_id: int, abort: bool = False, delete_job: bool = False
+        self,
+        job_id: int,
+        abort: bool = False,
+        delete_job: bool = False,
+        connection: Any | None = None,
     ) -> bool:
         """
         Cancel a job by id.
@@ -364,6 +368,8 @@ class JobManager:
         delete_job:
             If True, the job will be deleted from the database after being cancelled. Does
             not affect the jobs that should be aborted.
+        connection:
+            Optional external database connection to use for the query.
 
         Returns
         -------
@@ -372,12 +378,23 @@ class JobManager:
             nothing was done: either there is no job with this id or it's not in a state
             where it may be cancelled (i.e. `todo` or `doing`)
         """
-        result = self.connector.get_sync_connector().execute_query_one(
-            query=sql.queries["cancel_job"],
-            job_id=job_id,
-            abort=abort,
-            delete_job=delete_job,
-        )
+        if connection is not None:
+            result = (
+                self.connector.get_sync_connector().execute_query_one_with_connection(
+                    connection,
+                    query=sql.queries["cancel_job"],
+                    job_id=job_id,
+                    abort=abort,
+                    delete_job=delete_job,
+                )
+            )
+        else:
+            result = self.connector.get_sync_connector().execute_query_one(
+                query=sql.queries["cancel_job"],
+                job_id=job_id,
+                abort=abort,
+                delete_job=delete_job,
+            )
 
         if result["id"] is None:
             return False
@@ -386,7 +403,11 @@ class JobManager:
         return True
 
     async def cancel_job_by_id_async(
-        self, job_id: int, abort: bool = False, delete_job: bool = False
+        self,
+        job_id: int,
+        abort: bool = False,
+        delete_job: bool = False,
+        connection: Any | None = None,
     ) -> bool:
         """
         Cancel a job by id.
@@ -402,6 +423,8 @@ class JobManager:
         delete_job:
             If True, the job will be deleted from the database after being cancelled. Does
             not affect the jobs that should be aborted.
+        connection:
+            Optional external database connection to use for the query.
 
         Returns
         -------
@@ -410,12 +433,21 @@ class JobManager:
             nothing was done: either there is no job with this id or it's not in a state
             where it may be cancelled (i.e. `todo` or `doing`)
         """
-        result = await self.connector.execute_query_one_async(
-            query=sql.queries["cancel_job"],
-            job_id=job_id,
-            abort=abort,
-            delete_job=delete_job,
-        )
+        if connection is not None:
+            result = await self.connector.execute_query_one_async_with_connection(
+                connection,
+                query=sql.queries["cancel_job"],
+                job_id=job_id,
+                abort=abort,
+                delete_job=delete_job,
+            )
+        else:
+            result = await self.connector.execute_query_one_async(
+                query=sql.queries["cancel_job"],
+                job_id=job_id,
+                abort=abort,
+                delete_job=delete_job,
+            )
 
         if result["id"] is None:
             return False
@@ -423,7 +455,9 @@ class JobManager:
         assert result["id"] == job_id
         return True
 
-    def get_job_status(self, job_id: int) -> jobs_module.Status:
+    def get_job_status(
+        self, job_id: int, connection: Any | None = None
+    ) -> jobs_module.Status:
         """
         Get the status of a job by id.
 
@@ -431,17 +465,28 @@ class JobManager:
         ----------
         job_id:
             The id of the job to get the status of
+        connection:
+            Optional external database connection to use for the query.
 
         Returns
         -------
         :
         """
-        result = self.connector.get_sync_connector().execute_query_one(
-            query=sql.queries["get_job_status"], job_id=job_id
-        )
+        if connection is not None:
+            result = (
+                self.connector.get_sync_connector().execute_query_one_with_connection(
+                    connection, query=sql.queries["get_job_status"], job_id=job_id
+                )
+            )
+        else:
+            result = self.connector.get_sync_connector().execute_query_one(
+                query=sql.queries["get_job_status"], job_id=job_id
+            )
         return jobs_module.Status(result["status"])
 
-    async def get_job_status_async(self, job_id: int) -> jobs_module.Status:
+    async def get_job_status_async(
+        self, job_id: int, connection: Any | None = None
+    ) -> jobs_module.Status:
         """
         Get the status of a job by id.
 
@@ -449,14 +494,21 @@ class JobManager:
         ----------
         job_id:
             The id of the job to get the status of
+        connection:
+            Optional external database connection to use for the query.
 
         Returns
         -------
         :
         """
-        result = await self.connector.execute_query_one_async(
-            query=sql.queries["get_job_status"], job_id=job_id
-        )
+        if connection is not None:
+            result = await self.connector.execute_query_one_async_with_connection(
+                connection, query=sql.queries["get_job_status"], job_id=job_id
+            )
+        else:
+            result = await self.connector.execute_query_one_async(
+                query=sql.queries["get_job_status"], job_id=job_id
+            )
         return jobs_module.Status(result["status"])
 
     async def retry_job(

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -378,18 +378,17 @@ class JobManager:
             nothing was done: either there is no job with this id or it's not in a state
             where it may be cancelled (i.e. `todo` or `doing`)
         """
+        sync_connector = self.connector.get_sync_connector()
         if connection is not None:
-            result = (
-                self.connector.get_sync_connector().execute_query_one_with_connection(
-                    connection,
-                    query=sql.queries["cancel_job"],
-                    job_id=job_id,
-                    abort=abort,
-                    delete_job=delete_job,
-                )
+            result = sync_connector.execute_query_one_with_connection(
+                connection,
+                query=sql.queries["cancel_job"],
+                job_id=job_id,
+                abort=abort,
+                delete_job=delete_job,
             )
         else:
-            result = self.connector.get_sync_connector().execute_query_one(
+            result = sync_connector.execute_query_one(
                 query=sql.queries["cancel_job"],
                 job_id=job_id,
                 abort=abort,
@@ -472,14 +471,13 @@ class JobManager:
         -------
         :
         """
+        sync_connector = self.connector.get_sync_connector()
         if connection is not None:
-            result = (
-                self.connector.get_sync_connector().execute_query_one_with_connection(
-                    connection, query=sql.queries["get_job_status"], job_id=job_id
-                )
+            result = sync_connector.execute_query_one_with_connection(
+                connection, query=sql.queries["get_job_status"], job_id=job_id
             )
         else:
-            result = self.connector.get_sync_connector().execute_query_one(
+            result = sync_connector.execute_query_one(
                 query=sql.queries["get_job_status"], job_id=job_id
             )
         return jobs_module.Status(result["status"])

--- a/procrastinate/psycopg_connector.py
+++ b/procrastinate/psycopg_connector.py
@@ -248,6 +248,22 @@ class PsycopgConnector(connector.BaseAsyncConnector):
             return await cursor.fetchall()
 
     @wrap_exceptions()
+    async def execute_query_one_async_with_connection(
+        self,
+        connection: psycopg.AsyncConnection,
+        query: LiteralString,
+        **arguments: Any,
+    ) -> dict[str, Any]:
+        async with self._get_cursor(connection=connection) as cursor:
+            await cursor.execute(query, self._wrap_json(arguments))
+
+            result = await cursor.fetchone()
+
+            if result is None:
+                raise exceptions.NoResult
+            return result
+
+    @wrap_exceptions()
     async def execute_query_all_async_with_connection(
         self,
         connection: psycopg.AsyncConnection,

--- a/procrastinate/sync_psycopg_connector.py
+++ b/procrastinate/sync_psycopg_connector.py
@@ -204,6 +204,19 @@ class SyncPsycopgConnector(connector.BaseConnector):
             return cursor.fetchall()
 
     @wrap_exceptions()
+    def execute_query_one_with_connection(
+        self, connection: psycopg.Connection, query: LiteralString, **arguments: Any
+    ) -> dict[str, Any]:
+        with self._get_cursor(connection=connection) as cursor:
+            cursor.execute(query, self._wrap_json(arguments))
+
+            result = cursor.fetchone()
+
+            if result is None:
+                raise exceptions.NoResult
+            return result
+
+    @wrap_exceptions()
     def execute_query_all_with_connection(
         self, connection: psycopg.Connection, query: LiteralString, **arguments: Any
     ) -> list[dict[str, Any]]:

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -89,6 +89,16 @@ class InMemoryConnector(connector.BaseAsyncConnector):
     ) -> list[dict[str, Any]]:
         return await self.generic_execute(query, "all", **arguments)
 
+    def execute_query_one_with_connection(
+        self, connection: Any, query: str, **arguments: Any
+    ) -> dict[str, Any]:
+        return utils.async_to_sync(self.execute_query_one_async, query, **arguments)
+
+    async def execute_query_one_async_with_connection(
+        self, connection: Any, query: str, **arguments: Any
+    ) -> dict[str, Any]:
+        return await self.execute_query_one_async(query, **arguments)
+
     def execute_query_all_with_connection(
         self, connection: Any, query: str, **arguments: Any
     ) -> list[dict[str, Any]]:

--- a/tests/integration/contrib/sqlalchemy/test_psycopg2_connector.py
+++ b/tests/integration/contrib/sqlalchemy/test_psycopg2_connector.py
@@ -289,3 +289,71 @@ def test_batch_defer_with_external_connection_rollback(sqlalchemy_psycopg2_conne
         worker_id=None,
     )
     assert len(jobs) == 0
+
+
+def test_execute_query_one_with_connection(sqlalchemy_psycopg2_connector):
+    with sqlalchemy_psycopg2_connector.engine.connect() as conn:
+        result = sqlalchemy_psycopg2_connector.execute_query_one_with_connection(
+            conn, "SELECT %(arg)s as col", arg=1
+        )
+    assert result == {"col": 1}
+
+
+def test_cancel_job_with_external_connection_commit(sqlalchemy_psycopg2_connector):
+    from procrastinate import App, jobs
+
+    app = App(connector=sqlalchemy_psycopg2_connector)
+    app.open()
+
+    @app.task
+    def my_sqla_cancel_task(x):
+        pass
+
+    job_id = my_sqla_cancel_task.defer(x=1)
+
+    with sqlalchemy_psycopg2_connector.engine.connect() as conn:
+        cancelled = app.job_manager.cancel_job_by_id(job_id, connection=conn)
+        assert cancelled is True
+        conn.commit()
+
+    status = app.job_manager.get_job_status(job_id)
+    assert status == jobs.Status.CANCELLED
+
+
+def test_cancel_job_with_external_connection_rollback(sqlalchemy_psycopg2_connector):
+    from procrastinate import App, jobs
+
+    app = App(connector=sqlalchemy_psycopg2_connector)
+    app.open()
+
+    @app.task
+    def my_sqla_cancel_rollback_task(x):
+        pass
+
+    job_id = my_sqla_cancel_rollback_task.defer(x=1)
+
+    with sqlalchemy_psycopg2_connector.engine.connect() as conn:
+        cancelled = app.job_manager.cancel_job_by_id(job_id, connection=conn)
+        assert cancelled is True
+        conn.rollback()
+
+    # The cancellation was rolled back, the job is still up for grabs
+    status = app.job_manager.get_job_status(job_id)
+    assert status == jobs.Status.TODO
+
+
+def test_get_job_status_with_external_connection(sqlalchemy_psycopg2_connector):
+    from procrastinate import App, jobs
+
+    app = App(connector=sqlalchemy_psycopg2_connector)
+    app.open()
+
+    @app.task
+    def my_sqla_status_task(x):
+        pass
+
+    job_id = my_sqla_status_task.defer(x=1)
+
+    with sqlalchemy_psycopg2_connector.engine.connect() as conn:
+        status = app.job_manager.get_job_status(job_id, connection=conn)
+    assert status == jobs.Status.TODO

--- a/tests/integration/test_psycopg_connector.py
+++ b/tests/integration/test_psycopg_connector.py
@@ -445,3 +445,96 @@ async def test_batch_defer_with_external_connection_rollback(
         worker_id=None,
     )
     assert len(jobs) == 0
+
+
+async def test_execute_query_one_async_with_connection(psycopg_connector):
+    async with psycopg_connector.pool.connection() as conn:
+        result = await psycopg_connector.execute_query_one_async_with_connection(
+            conn, "SELECT %(arg)s as col", arg=1
+        )
+    assert result == {"col": 1}
+
+
+async def test_cancel_job_with_external_connection_commit(
+    psycopg_connector, connection_params
+):
+    import psycopg
+
+    from procrastinate import App, jobs
+
+    app = App(connector=psycopg_connector)
+    await app.open_async()
+
+    @app.task
+    def my_async_cancel_task(x):
+        pass
+
+    job_id = await my_async_cancel_task.defer_async(x=1)
+
+    conninfo = psycopg.conninfo.make_conninfo(**connection_params)
+    async with await psycopg.AsyncConnection.connect(
+        conninfo, autocommit=False
+    ) as conn:
+        cancelled = await app.job_manager.cancel_job_by_id_async(
+            job_id, connection=conn
+        )
+        assert cancelled is True
+        await conn.commit()
+
+    status = await app.job_manager.get_job_status_async(job_id)
+    assert status == jobs.Status.CANCELLED
+
+
+async def test_cancel_job_with_external_connection_rollback(
+    psycopg_connector, connection_params
+):
+    import psycopg
+
+    from procrastinate import App, jobs
+
+    app = App(connector=psycopg_connector)
+    await app.open_async()
+
+    @app.task
+    def my_async_cancel_rollback_task(x):
+        pass
+
+    job_id = await my_async_cancel_rollback_task.defer_async(x=1)
+
+    conninfo = psycopg.conninfo.make_conninfo(**connection_params)
+    async with await psycopg.AsyncConnection.connect(
+        conninfo, autocommit=False
+    ) as conn:
+        cancelled = await app.job_manager.cancel_job_by_id_async(
+            job_id, connection=conn
+        )
+        assert cancelled is True
+        await conn.rollback()
+
+    # The cancellation was rolled back, the job is still up for grabs
+    status = await app.job_manager.get_job_status_async(job_id)
+    assert status == jobs.Status.TODO
+
+
+async def test_get_job_status_with_external_connection(
+    psycopg_connector, connection_params
+):
+    import psycopg
+
+    from procrastinate import App, jobs
+
+    app = App(connector=psycopg_connector)
+    await app.open_async()
+
+    @app.task
+    def my_async_status_task(x):
+        pass
+
+    job_id = await my_async_status_task.defer_async(x=1)
+
+    conninfo = psycopg.conninfo.make_conninfo(**connection_params)
+    async with await psycopg.AsyncConnection.connect(
+        conninfo, autocommit=False
+    ) as conn:
+        status = await app.job_manager.get_job_status_async(job_id, connection=conn)
+    assert status == jobs.Status.TODO

--- a/tests/integration/test_sync_psycopg_connector.py
+++ b/tests/integration/test_sync_psycopg_connector.py
@@ -247,3 +247,89 @@ def test_batch_defer_with_external_connection_rollback(
         worker_id=None,
     )
     assert len(jobs) == 0
+
+
+def test_execute_query_one_with_connection(sync_psycopg_connector):
+    with sync_psycopg_connector.pool.connection() as conn:
+        result = sync_psycopg_connector.execute_query_one_with_connection(
+            conn, "SELECT %(arg)s as col", arg=1
+        )
+    assert result == {"col": 1}
+
+
+def test_cancel_job_with_external_connection_commit(
+    sync_psycopg_connector, connection_params
+):
+    import psycopg
+
+    from procrastinate import App, jobs
+
+    app = App(connector=sync_psycopg_connector)
+    app.open()
+
+    @app.task
+    def my_cancel_task(x):
+        pass
+
+    job_id = my_cancel_task.defer(x=1)
+
+    conninfo = psycopg.conninfo.make_conninfo(**connection_params)
+    with psycopg.connect(conninfo) as conn:
+        conn.autocommit = False
+        cancelled = app.job_manager.cancel_job_by_id(job_id, connection=conn)
+        assert cancelled is True
+        conn.commit()
+
+    status = app.job_manager.get_job_status(job_id)
+    assert status == jobs.Status.CANCELLED
+
+
+def test_cancel_job_with_external_connection_rollback(
+    sync_psycopg_connector, connection_params
+):
+    import psycopg
+
+    from procrastinate import App, jobs
+
+    app = App(connector=sync_psycopg_connector)
+    app.open()
+
+    @app.task
+    def my_cancel_rollback_task(x):
+        pass
+
+    job_id = my_cancel_rollback_task.defer(x=1)
+
+    conninfo = psycopg.conninfo.make_conninfo(**connection_params)
+    with psycopg.connect(conninfo) as conn:
+        conn.autocommit = False
+        cancelled = app.job_manager.cancel_job_by_id(job_id, connection=conn)
+        assert cancelled is True
+        conn.rollback()
+
+    # The cancellation was rolled back, the job is still up for grabs
+    status = app.job_manager.get_job_status(job_id)
+    assert status == jobs.Status.TODO
+
+
+def test_get_job_status_with_external_connection(
+    sync_psycopg_connector, connection_params
+):
+    import psycopg
+
+    from procrastinate import App, jobs
+
+    app = App(connector=sync_psycopg_connector)
+    app.open()
+
+    @app.task
+    def my_status_task(x):
+        pass
+
+    job_id = my_status_task.defer(x=1)
+
+    conninfo = psycopg.conninfo.make_conninfo(**connection_params)
+    with psycopg.connect(conninfo) as conn:
+        conn.autocommit = False
+        status = app.job_manager.get_job_status(job_id, connection=conn)
+    assert status == jobs.Status.TODO

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -738,3 +738,69 @@ async def test_unsupported_connector_raises_async():
     c = BaseConnector()
     with pytest.raises(exceptions.ConnectorException, match="does not support"):
         await c.execute_query_all_async_with_connection(object(), "SELECT 1")
+
+
+async def test_manager_cancel_job_no_connection_uses_normal_path(
+    mocker, job_manager, job_factory, connector
+):
+    job = await job_manager.defer_job_async(
+        job=job_factory(id=None, task_kwargs={"a": "b"}, task_name="bla"),
+    )
+    spy = mocker.spy(connector, "execute_query_one_async")
+    assert await job_manager.cancel_job_by_id_async(job.id) is True
+    spy.assert_called_once()
+
+
+async def test_manager_cancel_job_with_connection_uses_connection_path(
+    mocker, job_manager, job_factory, connector
+):
+    job = await job_manager.defer_job_async(
+        job=job_factory(id=None, task_kwargs={"a": "b"}, task_name="bla"),
+    )
+    spy = mocker.spy(connector, "execute_query_one_async_with_connection")
+    mock_conn = object()
+    cancelled = await job_manager.cancel_job_by_id_async(job.id, connection=mock_conn)
+    assert cancelled is True
+    spy.assert_called_once()
+    assert spy.call_args[0][0] is mock_conn
+
+
+async def test_manager_get_job_status_no_connection_uses_normal_path(
+    mocker, job_manager, job_factory, connector
+):
+    job = await job_manager.defer_job_async(
+        job=job_factory(id=None, task_kwargs={"a": "b"}, task_name="bla"),
+    )
+    spy = mocker.spy(connector, "execute_query_one_async")
+    assert await job_manager.get_job_status_async(job.id) == jobs.Status.TODO
+    spy.assert_called_once()
+
+
+async def test_manager_get_job_status_with_connection_uses_connection_path(
+    mocker, job_manager, job_factory, connector
+):
+    job = await job_manager.defer_job_async(
+        job=job_factory(id=None, task_kwargs={"a": "b"}, task_name="bla"),
+    )
+    spy = mocker.spy(connector, "execute_query_one_async_with_connection")
+    mock_conn = object()
+    status = await job_manager.get_job_status_async(job.id, connection=mock_conn)
+    assert status == jobs.Status.TODO
+    spy.assert_called_once()
+    assert spy.call_args[0][0] is mock_conn
+
+
+def test_unsupported_connector_raises_query_one():
+    from procrastinate.connector import BaseConnector
+
+    c = BaseConnector()
+    with pytest.raises(exceptions.ConnectorException, match="does not support"):
+        c.execute_query_one_with_connection(object(), "SELECT 1")
+
+
+async def test_unsupported_connector_raises_query_one_async():
+    from procrastinate.connector import BaseConnector
+
+    c = BaseConnector()
+    with pytest.raises(exceptions.ConnectorException, match="does not support"):
+        await c.execute_query_one_async_with_connection(object(), "SELECT 1")


### PR DESCRIPTION
Follow-up to #1508. `cancel_job_by_id` / `cancel_job_by_id_async` and `get_job_status` / `get_job_status_async` now take the same optional `connection=` argument as defer, so they can run on a user-managed connection inside the caller's own transaction. If you update your own tables when cancelling a job, both changes commit (or roll back) together.

The implementation follows the same pattern: new `execute_query_one_*_with_connection` methods on the connector interface next to the existing `execute_query_all_*` ones, implemented for `SyncPsycopgConnector`, `PsycopgConnector` and `SQLAlchemyPsycopg2Connector`. Other connectors keep raising `ConnectorException`. When `connection` isn't passed, nothing changes.

One note on the approach: this adds two more `*_with_connection` methods, and I know from the review on that PR (https://github.com/procrastinate-org/procrastinate/pull/1508#discussion_r3020389290) that multiplying these isn't the preferred long-term direction. I kept the existing pattern for consistency, but happy to rework it to fold `connection=` into the regular `execute_query_*` methods if you'd rather go that way now.

Closes #1550

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job cancellation and job-status retrieval now support externally-managed database connections, enabling transactional workflows within caller-controlled commits and rollbacks.

* **Documentation**
  * Production guide expanded with a dedicated section and examples for cancelling jobs and reading status using the same external connection, including updated timing notes.

* **Tests**
  * Added unit and integration coverage for connection-scoped cancellation/status across supported connectors, including commit/rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->