### PR TITLE
Fix App.task / Blueprint.task not rendering in the API reference

### DIFF
--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -213,51 +213,7 @@ class Blueprint:
         lock: str | None = None,
         queueing_lock: str | None = None,
         task_middleware: list[middleware.TaskMiddleware] | None = None,
-    ) -> Callable[[Callable[P, R]], Task[P, R, P]]:
-        """Declare a function as a task. This method is meant to be used as a decorator
-        Parameters
-        ----------
-        queue :
-            The name of the queue in which jobs from this task will be launched, if
-            the queue is not overridden at launch.
-            Default is ``"default"``.
-            When a worker is launched, it can listen to specific queues, or to all
-            queues.
-        lock :
-            Default value for the ``lock`` (see `Task.defer`).
-        queueing_lock:
-            Default value for the ``queueing_lock`` (see `Task.defer`).
-        name :
-            Name of the task, by default the full dotted path to the decorated function.
-            if the function is nested or dynamically defined, it is important to give
-            it a unique name, and to make sure the module that defines this function
-            is listed in the ``import_paths`` of the `procrastinate.App`.
-        priority :
-            Default priority (an integer) of jobs that are deferred from this task.
-            Jobs with higher priority are run first. Priority can be positive or negative.
-            If no default priority is set then the default priority is 0.
-        aliases:
-            Additional names for the task.
-            The main use case is to gracefully rename tasks by moving the old
-            name to aliases (these tasks can have been scheduled in a distant
-            future, so the aliases can remain for a long time).
-        retry :
-            Details how to auto-retry the task if it fails. Can be:
-
-            - A ``boolean``: will either not retry or retry indefinitely
-            - An ``int``: the number of retries before it gives up
-            - A `procrastinate.RetryStrategy` instance for complex cases
-
-            Default is no retry.
-        pass_context :
-            Passes the task execution context in the task as first
-        task_middleware :
-            A list of middlewares wrapping this task's execution. Each must match
-            the task's nature: sync middleware (a plain function) for a sync task,
-            async middleware (a coroutine function) for an async task. See
-            `howto/advanced/middleware`.
-        """
-        ...
+    ) -> Callable[[Callable[P, R]], Task[P, R, P]]: ...
 
     @overload
     def task(
@@ -276,24 +232,10 @@ class Blueprint:
     ) -> Callable[
         [Callable[Concatenate[JobContext, P], R]],
         Task[Concatenate[JobContext, P], R, P],
-    ]:
-        """Declare a function as a task. This method is meant to be used as a decorator
-        Parameters
-        ----------
-        _func :
-            The decorated function
-        """
-        ...
+    ]: ...
 
     @overload
-    def task(self, _func: Callable[P, R]) -> Task[P, R, P]:
-        """Declare a function as a task. This method is meant to be used as a decorator
-        Parameters
-        ----------
-        _func :
-            The decorated function
-        """
-        ...
+    def task(self, _func: Callable[P, R]) -> Task[P, R, P]: ...
 
     def task(
         self,
@@ -309,10 +251,9 @@ class Blueprint:
         queueing_lock: str | None = None,
         task_middleware: list[middleware.TaskMiddleware] | None = None,
     ):
-        from procrastinate.tasks import Task
-
         """
-        Declare a function as a task. This method is meant to be used as a decorator::
+        Declare a function as a task. This method is meant to be used as a
+        decorator::
 
             @app.task(...)
             def my_task(args):
@@ -323,8 +264,55 @@ class Blueprint:
             @app.task
             def my_task(args):
                 ...
+
         The second form will use the default value for all parameters.
+
+        Parameters
+        ----------
+        _func :
+            The decorated function, when the decorator is used without parentheses
+            (``@app.task``). Don't pass it explicitly.
+        name :
+            Name of the task, by default the full dotted path to the decorated function.
+            If the function is nested or dynamically defined, it is important to give
+            it a unique name, and to make sure the module that defines this function
+            is listed in the ``import_paths`` of the `procrastinate.App`.
+        aliases :
+            Additional names for the task.
+            The main use case is to gracefully rename tasks by moving the old
+            name to aliases (these tasks can have been scheduled in a distant
+            future, so the aliases can remain for a long time).
+        retry :
+            Details how to auto-retry the task if it fails. Can be:
+
+            - A ``boolean``: will either not retry or retry indefinitely
+            - An ``int``: the number of retries before it gives up
+            - A `procrastinate.RetryStrategy` instance for complex cases
+
+            Default is no retry.
+        pass_context :
+            Passes the task execution context in the task as first argument.
+        queue :
+            The name of the queue in which jobs from this task will be launched, if
+            the queue is not overridden at launch.
+            Default is ``"default"``.
+            When a worker is launched, it can listen to specific queues, or to all
+            queues.
+        priority :
+            Default priority (an integer) of jobs that are deferred from this task.
+            Jobs with higher priority are run first. Priority can be positive or negative.
+            If no default priority is set then the default priority is 0.
+        lock :
+            Default value for the ``lock`` (see `Task.defer`).
+        queueing_lock :
+            Default value for the ``queueing_lock`` (see `Task.defer`).
+        task_middleware :
+            A list of middlewares wrapping this task's execution. Each must match
+            the task's nature: sync middleware (a plain function) for a sync task,
+            async middleware (a coroutine function) for an async task. See
+            `howto/advanced/middleware`.
         """
+        from procrastinate.tasks import Task
 
         def _wrap(func: Callable[P, R]) -> Task[P, R, P]:
             task = Task(


### PR DESCRIPTION
Closes #1561

## Problem

`App.task` and `Blueprint.task` were missing from the rendered [API reference](https://procrastinate.readthedocs.io/en/stable/reference.html) despite being listed in `:members:`: the implementation's docstring sat *after* `from procrastinate.tasks import Task`, making it a discarded expression (`__doc__` was `None`), so autodoc silently skipped the member. The per-parameter docs lived only in the first `@overload`'s docstring, which autodoc never reads.

## Fix

- Move the docstring to be the first statement of the implementation (import below it).
- Consolidate the parameter documentation from the overloads into the implementation docstring — single source of truth. Pyright falls back to the implementation docstring when the matched overload has none, so IDE hover keeps working; the overload stub docstrings are removed.
- While moving the text: document `_func` (it rendered as a bare name-plus-type otherwise, since `autodoc_typehints = "both"` appends all signature params), reorder the parameter docs to match the signature order, fix the truncated `pass_context` sentence and a lowercase "if".

## Verification

- `scripts/docs` (strict `-EW`) builds clean; `reference.html` now renders both `procrastinate.App.task` and `procrastinate.blueprints.Blueprint.task` with the usage examples and the full parameter list.
- basedpyright, ruff check/format, and the unit test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for the `Blueprint.task` decorator with expanded parameter descriptions and clearer organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->