### PR TITLE
Fix worker stop request lost during startup and de-flake shutdown tests

### DIFF
--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -421,6 +421,11 @@ class Worker:
         Run the worker
         This will run forever until asked to stop/cancelled, or until no more job is available is configured not to wait
         """
+        # Reset a stale stop request from a previous run. This must happen before
+        # the first await: anything later (e.g. the top of the run loop task) can
+        # run after a fresh stop() and erase it, leaving the worker unstoppable.
+        self._stop_event.clear()
+
         logger.debug("Pruning stalled workers with old heartbeats")
         pruned_workers = await self.app.job_manager.prune_stalled_workers(
             self.stalled_worker_timeout
@@ -640,7 +645,6 @@ class Worker:
             ),
         )
         self._new_job_event.clear()
-        self._stop_event.clear()
         self._running_jobs = {}
         self._job_semaphore = asyncio.Semaphore(self.concurrency)
         side_tasks = self._start_side_tasks()

--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -24,6 +24,16 @@ async def async_app(request, psycopg_connector, connection_params):
         yield app
 
 
+async def wait_for_job_status(
+    app: app_module.App, job_id: int, status: Status, timeout: float = 5
+):
+    async def poll():
+        while await app.job_manager.get_job_status_async(job_id) != status:
+            await asyncio.sleep(0.02)
+
+    await asyncio.wait_for(poll(), timeout)
+
+
 async def test_defer(async_app: app_module.App):
     sum_results = []
     product_results = []
@@ -349,7 +359,7 @@ async def test_stop_worker_aborts_async_jobs_past_shutdown_graceful_timeout(
     run_task = asyncio.create_task(
         async_app.run_worker_async(wait=False, shutdown_graceful_timeout=0.3)
     )
-    await asyncio.sleep(0.05)
+    await wait_for_job_status(async_app, slow_job_id, Status.DOING)
 
     with pytest.raises(asyncio.CancelledError):
         run_task.cancel()
@@ -382,7 +392,7 @@ async def test_stop_worker_retries_async_jobs_past_shutdown_graceful_timeout(
     run_task = asyncio.create_task(
         async_app.run_worker_async(wait=False, shutdown_graceful_timeout=0.3)
     )
-    await asyncio.sleep(0.05)
+    await wait_for_job_status(async_app, slow_job_id, Status.DOING)
 
     with pytest.raises(asyncio.CancelledError):
         run_task.cancel()
@@ -417,7 +427,7 @@ async def test_stop_worker_aborts_sync_jobs_past_shutdown_graceful_timeout(
     run_task = asyncio.create_task(
         async_app.run_worker_async(wait=False, shutdown_graceful_timeout=0.3)
     )
-    await asyncio.sleep(0.05)
+    await wait_for_job_status(async_app, slow_job_id, Status.DOING)
 
     with pytest.raises(asyncio.CancelledError):
         run_task.cancel()
@@ -452,7 +462,7 @@ async def test_stop_worker_retries_sync_jobs_past_shutdown_graceful_timeout(
     run_task = asyncio.create_task(
         async_app.run_worker_async(wait=False, shutdown_graceful_timeout=0.3)
     )
-    await asyncio.sleep(0.05)
+    await wait_for_job_status(async_app, slow_job_id, Status.DOING)
 
     with pytest.raises(asyncio.CancelledError):
         run_task.cancel()

--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -149,11 +149,15 @@ async def test_no_job_to_cancel_found(async_app: app_module.App):
 async def test_abort_async_task(async_app: app_module.App, mode):
     @async_app.task(queue="default", name="task1")
     async def task1():
-        await asyncio.sleep(0.5)
+        # Outlasts the wait_for timeouts below, so the abort always wins; on
+        # success the sleep is cancelled and the duration never elapses.
+        await asyncio.sleep(3)
 
     job_id = await task1.defer_async()
 
-    abort_job_polling_interval = 0.1
+    # In listen mode, the polling interval is far beyond the wait_for timeout
+    # below, so the test can only pass through the notification path.
+    abort_job_polling_interval = 0.1 if mode == "poll" else 30
 
     worker_task = asyncio.create_task(
         async_app.run_worker_async(
@@ -164,15 +168,13 @@ async def test_abort_async_task(async_app: app_module.App, mode):
         )
     )
 
-    await asyncio.sleep(0.05)
+    await wait_for_job_status(async_app, job_id, Status.DOING)
     result = await async_app.job_manager.cancel_job_by_id_async(job_id, abort=True)
     assert result is True
 
-    # when listening for notifications, job should cancel within ms
-    # if notifications are disabled, job will only cancel after abort_job_polling_interval
-    await asyncio.wait_for(
-        worker_task, timeout=0.1 if mode == "listen" else abort_job_polling_interval * 2
-    )
+    # Generous multiples of the expected latency (notification: ms, polling: one
+    # 0.1s interval) so a slow CI runner doesn't fail the test.
+    await asyncio.wait_for(worker_task, timeout=1 if mode == "listen" else 2)
 
     status = await async_app.job_manager.get_job_status_async(job_id)
     assert status == Status.ABORTED
@@ -189,7 +191,9 @@ async def test_abort_sync_task(async_app: app_module.App, mode):
 
     job_id = await task1.defer_async()
 
-    abort_job_polling_interval = 0.1
+    # In listen mode, the polling interval is far beyond the wait_for timeout
+    # below, so the test can only pass through the notification path.
+    abort_job_polling_interval = 0.1 if mode == "poll" else 30
 
     worker_task = asyncio.create_task(
         async_app.run_worker_async(
@@ -200,15 +204,13 @@ async def test_abort_sync_task(async_app: app_module.App, mode):
         )
     )
 
-    await asyncio.sleep(0.05)
+    await wait_for_job_status(async_app, job_id, Status.DOING)
     result = await async_app.job_manager.cancel_job_by_id_async(job_id, abort=True)
     assert result is True
 
-    # when listening for notifications, job should cancel within ms
-    # if notifications are disabled, job will only cancel after abort_job_polling_interval
-    await asyncio.wait_for(
-        worker_task, timeout=0.1 if mode == "listen" else abort_job_polling_interval * 2
-    )
+    # Generous multiples of the expected latency (notification: ms, polling: one
+    # 0.1s interval) so a slow CI runner doesn't fail the test.
+    await asyncio.wait_for(worker_task, timeout=1 if mode == "listen" else 2)
 
     status = await async_app.job_manager.get_job_status_async(job_id)
     assert status == Status.ABORTED

--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -326,7 +326,8 @@ async def test_stop_worker(async_app: app_module.App):
     job_ids.append(await appender.defer_async(a=2))
 
     run_task = asyncio.create_task(async_app.run_worker_async(concurrency=2, wait=True))
-    await asyncio.sleep(0.5)
+    for job_id in job_ids:
+        await wait_for_job_status(async_app, job_id, Status.SUCCEEDED)
 
     with pytest.raises(asyncio.CancelledError):
         run_task.cancel()
@@ -434,8 +435,6 @@ async def test_stop_worker_aborts_sync_jobs_past_shutdown_graceful_timeout(
     with pytest.raises(asyncio.CancelledError):
         run_task.cancel()
         await run_task
-
-    await asyncio.sleep(0.05)
 
     fast_job_status = await async_app.job_manager.get_job_status_async(fast_job_id)
     slow_job_status = await async_app.job_manager.get_job_status_async(slow_job_id)

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -84,6 +84,23 @@ async def test_worker_run_wait_stop(app: App, caplog):
     }
 
 
+async def test_stop_requested_before_run_loop_starts_is_not_lost(app: App):
+    worker = Worker(app, wait=True, install_signal_handlers=False)
+
+    original_run_loop = worker._run_loop
+
+    async def run_loop_with_late_start():
+        # Simulate a stop() landing after run() scheduled the run loop task but
+        # before the task's first statement; if it gets erased, with wait=True
+        # the worker runs forever.
+        worker.stop()
+        await original_run_loop()
+
+    worker._run_loop = run_loop_with_late_start
+
+    await asyncio.wait_for(worker.run(), timeout=2)
+
+
 def test_stop_after_run_exited_with_error_does_not_raise(not_opened_app: App):
     # If run() dies on an exception (e.g. a database error), the stop event is
     # never set and the worker's event loop ends up closed. A late stop() (e.g.


### PR DESCRIPTION
Closes #1563

## Worker fix

A `stop()` (e.g. from cancelling `run_worker_async`) landing after `run()` has scheduled the run loop task but before that task's first execution slot was erased by the `_stop_event.clear()` at the top of `_run_loop`, leaving the worker unstoppable: graceful shutdown never starts, a sync job polling `should_abort()` spins forever, and `await run()` never returns.

The clear now happens synchronously at the top of `run()`, before the first await, so no stop requested after `run()` has started can be erased. Observable behavior is otherwise unchanged: a stop requested before `run()` starts is still discarded, and worker instances remain reusable.

`test_stop_requested_before_run_loop_starts_is_not_lost` models the race window deterministically (a stop injected between the loop task's creation and its first statement) — it deadlocks (times out) on main and passes with the fix.

## Test de-flake

The four `*_past_shutdown_graceful_timeout` acceptance tests cancelled the worker after a fixed 50 ms sleep, racing worker startup on slow CI runners — the failure seen on main ([run](https://github.com/procrastinate-org/procrastinate/actions/runs/27297387907/job/80633639248)): cancel won the race, the worker shut down cleanly before fetching anything, and the test failed with `TODO != SUCCEEDED`. They now poll until the slow job reaches `doing` (new `wait_for_job_status` helper) before cancelling, which also guarantees the fast job — fetched first by id order — was already processed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worker now respects stop requests issued during startup, preventing a previous stop from making the worker unresponsive.

* **Tests**
  * Added and updated async acceptance and unit tests to reliably wait for job state transitions and verify worker stop behavior during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Abort test de-flake

While this PR was open, `test_abort_sync_task[aiopg_connector-poll]` failed on its CI run — a third member of the same flaky family. The two abort tests slept a fixed 50 ms before aborting (racing worker startup, so the abort could target a still-`todo` job and test plain cancellation instead of abort) and then gave the worker only `2 × abort_job_polling_interval = 0.2s` to poll the abort, persist, fetch once more, and shut down.

They now wait for the job to reach `doing` before aborting and use timeouts with ~10x margin (1s listen / 2s poll). The listen/poll discrimination moves from the timeout into the polling interval: in listen mode the interval (30s) lies far beyond the timeout, so the test can only pass through the notification path — previously a pass could plausibly be explained by the abort poller. The async task's sleep is lengthened so the abort can never lose against the task completing normally; on success the sleep is cancelled, and the tests run as fast as before (measured: 1.12s → 0.91s for the 8 abort tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
