### PR TITLE
Fix Renovate blockers: ignore pre-commit.ci commits and re-pin benchmark action

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,11 @@
     enabled: true,
     automerge: true,
   },
+  // pre-commit.ci pushes autofix commits onto Renovate branches; without this,
+  // Renovate treats them as manual edits and stops updating the PR.
+  gitIgnoredAuthors: [
+    '66853113+pre-commit-ci[bot]@users.noreply.github.com',
+  ],
   packageRules: [
     {
       groupName: 'all dependencies',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   extends: [
     'config:recommended',
     ':enablePreCommit',
+    'helpers:pinGitHubActionDigests',
   ],
   schedule: [
     'before 4am on Saturday',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Store benchmark result
         if: github.event_name == 'push' && github.ref_type == 'branch'
-        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1
+        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.22.1
         with:
           name: Procrastinate Benchmarks
           tool: "pytest"


### PR DESCRIPTION
## Changes

- **`.github/renovate.json5`**: add `gitIgnoredAuthors` for `pre-commit-ci[bot]`. The pre-commit.ci app pushes autofix commits onto Renovate branches, which Renovate treats as manual edits and then stops maintaining the PR — this is what left #1532 and #1503 stuck and conflicted since February/March. All 240 pre-commit.ci commits in this repo use the single author email `66853113+pre-commit-ci[bot]@users.noreply.github.com` (the ID is the bot's fixed GitHub user ID), so one entry covers it.

- **`.github/renovate.json5`**: extend from `helpers:pinGitHubActionDigests`. Most actions in CI are already digest-pinned; this makes Renovate pin the remaining tag-only references (`upload-artifact`, `download-artifact`, `python-coverage-comment-action`, `gh-action-pypi-publish` — the latter running in the release job with PyPI trusted publishing) and maintain those digests automatically. Expect a one-time follow-up PR from Renovate converting them to `@<sha> # <tag>` form.

- **`.github/workflows/ci.yml`**: re-pin `benchmark-action/github-action-benchmark` from a digest commented `# v1` to the `v1.22.1` tag digest (`4bdcce38c94cec68da58d012ac24b7b1155efe8b`, verified via the GitHub API). Upstream has no bare `v1` tag, so Renovate could not resolve a new digest and logged a "Package lookup failures" warning on the Dependency Dashboard, leaving the action frozen on an October 2024 commit. Pinning to a real tag lets Renovate track future updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended automation update configuration to include an additional preset and to ignore a specific bot's autofix commits, reducing unnecessary interruption of update flows.
  * Updated the pinned benchmark action to a newer commit to keep CI benchmark tooling current and consistent with other workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->