### PR TITLE
Remove gitIgnoredAuthors to stop Renovate/pre-commit.ci force-push loop

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,11 +14,6 @@
     enabled: true,
     automerge: true,
   },
-  // pre-commit.ci pushes autofix commits onto Renovate branches; without this,
-  // Renovate treats them as manual edits and stops updating the PR.
-  gitIgnoredAuthors: [
-    '66853113+pre-commit-ci[bot]@users.noreply.github.com',
-  ],
   packageRules: [
     {
       groupName: 'all dependencies',


### PR DESCRIPTION
## Problem

PR #1568 (`renovate/all`) got stuck in a tight loop: the branch was force-pushed roughly every 20 seconds, each push re-triggering the full CI matrix (50+ runs in ~20 minutes). Diagnosis showed consecutive force-pushes carried a **byte-identical tree** (`217f9c01…`) with only a new commit SHA — Renovate re-creating the same branch over and over.

## Root cause

The classic Renovate ↔ pre-commit.ci cycle, caused by `gitIgnoredAuthors`:

1. Renovate updates the `renovate/all` branch.
2. pre-commit.ci runs on the PR and pushes an autofix commit (a dependency bump such as ruff reformats a file).
3. Because pre-commit-ci is in `gitIgnoredAuthors`, Renovate does **not** treat the branch as externally modified, so it doesn't back off. It rebuilds its own clean tree, sees a diff against the remote (which now carries pre-commit.ci's commit), and **force-pushes over it**.
4. The force-push re-triggers pre-commit.ci → autofix → Renovate overwrites again → loop.

This is the documented `gitIgnoredAuthors` force-push behaviour: renovatebot/renovate#14656, #17528, #9351.

## Fix

Remove `gitIgnoredAuthors`. Renovate now treats pre-commit.ci commits as external modifications and leaves them alone instead of overwriting them, which breaks the cycle.

### Tradeoff

This reintroduces the earlier #1532/#1503 behaviour: when pre-commit.ci pushes an autofix onto a Renovate PR, Renovate leaves that PR alone until its next run / a manual rebase (a benign freeze) rather than overwriting it. A frozen PR is preferable to a CI-burning loop. If the freeze becomes a recurring nuisance, the follow-up is to stop pre-commit.ci from autofixing Renovate branches at the source, which removes both the loop and the freeze.

## Notes

- `renovate-config-validator` passes.
- Renovate reads its config from `main`, so the loop can only be fully resolved once this is merged. #1568 is marked Immortal and will be recreated on the next Renovate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to process commits from pre-commit bot instead of ignoring them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->