### PR TITLE
Stop Renovate from proposing setuptools major updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,17 @@
         '*',
       ],
     },
+    {
+      // setuptools 81 removed pkg_resources, which migra -> schemainspect
+      // still imports. Keep it below 81 (matching the pin in pyproject.toml)
+      matchPackageNames: [
+        'setuptools',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      enabled: false,
+    },
   ],
   automerge: true,
 }


### PR DESCRIPTION
Disable Renovate **major** updates for `setuptools`.

### Why
setuptools 81 removed the `pkg_resources` module, which `migra` -> `schemainspect` still imports, breaking collection of the migration tests. `pyproject.toml` already pins `setuptools<81` (commit f80148ea), but Renovate keeps opening PRs to widen the constraint — most recently #1571 (`<81` -> `<83`, which allows setuptools 82).

This adds a `packageRules` entry so Renovate stops creating those PRs until `schemainspect` drops its `pkg_resources` usage, at which point both this rule and the `pyproject.toml` pin can be removed.

#1571 is closed in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update rules to avoid automatic major-version upgrades for one package, helping prevent disruptive dependency changes.
  * Improved compatibility with newer releases by aligning update behavior with known breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->