### PR TITLE
Deflake test_sync_task_runs_in_parallel

### DIFF
--- a/tests/acceptance/test_sync.py
+++ b/tests/acceptance/test_sync.py
@@ -114,19 +114,19 @@ async def test_nested_sync_to_async(
 async def test_sync_task_runs_in_parallel(
     sync_app: procrastinate.App, async_app: procrastinate.App
 ):
-    results = []
+    timings = {}
 
     @sync_app.task(queue="default", name="sync_task_1")
     def sync_task_1():
-        for i in range(3):
-            time.sleep(0.1)
-            results.append(i)
+        timings["task_1_start"] = time.monotonic()
+        time.sleep(0.3)
+        timings["task_1_end"] = time.monotonic()
 
     @sync_app.task(queue="default", name="sync_task_2")
     def sync_task_2():
-        for i in range(3):
-            time.sleep(0.1)
-            results.append(i)
+        timings["task_2_start"] = time.monotonic()
+        time.sleep(0.3)
+        timings["task_2_end"] = time.monotonic()
 
     sync_task_1.defer()
     sync_task_2.defer()
@@ -134,7 +134,12 @@ async def test_sync_task_runs_in_parallel(
     async_app.tasks = sync_app.tasks
     await async_app.run_worker_async(queues=["default"], concurrency=2, wait=False)
 
-    assert results == [0, 0, 1, 1, 2, 2]
+    # If the tasks ran in parallel, their execution intervals overlap. If they
+    # ran sequentially, one task would finish before the other started. Checking
+    # the overlap avoids depending on an absolute duration threshold, which is
+    # sensitive to scheduling jitter on loaded CI.
+    assert timings["task_1_start"] < timings["task_2_end"]
+    assert timings["task_2_start"] < timings["task_1_end"]
 
 
 async def test_cancel(sync_app: procrastinate.App, async_app: procrastinate.App):

--- a/tests/acceptance/test_sync.py
+++ b/tests/acceptance/test_sync.py
@@ -119,13 +119,13 @@ async def test_sync_task_runs_in_parallel(
     @sync_app.task(queue="default", name="sync_task_1")
     def sync_task_1():
         timings["task_1_start"] = time.monotonic()
-        time.sleep(0.3)
+        time.sleep(0.2)
         timings["task_1_end"] = time.monotonic()
 
     @sync_app.task(queue="default", name="sync_task_2")
     def sync_task_2():
         timings["task_2_start"] = time.monotonic()
-        time.sleep(0.3)
+        time.sleep(0.2)
         timings["task_2_end"] = time.monotonic()
 
     sync_task_1.defer()
@@ -134,10 +134,6 @@ async def test_sync_task_runs_in_parallel(
     async_app.tasks = sync_app.tasks
     await async_app.run_worker_async(queues=["default"], concurrency=2, wait=False)
 
-    # If the tasks ran in parallel, their execution intervals overlap. If they
-    # ran sequentially, one task would finish before the other started. Checking
-    # the overlap avoids depending on an absolute duration threshold, which is
-    # sensitive to scheduling jitter on loaded CI.
     assert timings["task_1_start"] < timings["task_2_end"]
     assert timings["task_2_start"] < timings["task_1_end"]
 


### PR DESCRIPTION
`test_sync_task_runs_in_parallel` asserted an exact lock-step interleaving of two parallel sync tasks (`results == [0, 0, 1, 1, 2, 2]`), which depends on thread scheduling and fails intermittently on CI — e.g. `[0, 1, 0, 2, 1, 2]`, which still demonstrates parallelism but fails the assertion.

This replaces the assertion with an execution-interval overlap check: each task records its start/end time around a sleep, and the test asserts the two intervals overlap. Overlap is the actual definition of parallel execution, and it avoids an absolute timing threshold that could itself re-flake on loaded runners.

Part of the acceptance-test de-flake follow-up (#1563).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved the parallel task execution acceptance test to verify true concurrency by checking timing overlap between two concurrently running synchronous tasks, replacing prior deterministic ordering assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->