### PR TITLE
Clean up pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ extend-select = [
     "RUF", # ruff
 ]
 fixable = ["ALL"]
-extend-ignore = [
+ignore = [
     "E501", # line too long
     # It's not exactly false but it's not supported enough by our dependencies,
     # so ruff is fighting with Pyright on this.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,19 +2,6 @@
 requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
-[tool.hatch.version]
-source = "uv-dynamic-versioning"
-
-[tool.uv-dynamic-versioning]
-pattern = "default-unprefixed"
-
-[tool.hatch.build.targets.sdist]
-include = ["procrastinate"]
-exclude = ["procrastinate/demos"]
-
-[tool.hatch.build.targets.wheel]
-exclude = ["procrastinate/demos"]
-
 [project]
 name = "procrastinate"
 dynamic = ["version"]
@@ -60,11 +47,6 @@ changelog = "https://github.com/procrastinate-org/procrastinate/releases"
 [project.scripts]
 procrastinate = 'procrastinate.cli:main'
 
-[tool.uv]
-cache-keys = [{ git = { commit = true, tags = true } }]
-required-version = ">=0.5.21"
-default-groups = ["release", "lint_format", "pg_implem", "test", "docs"]
-
 [dependency-groups]
 types = ["django-stubs"]
 release = ["dunamai"]
@@ -90,6 +72,24 @@ docs = [
     "myst-parser",
 ]
 dev = ["ruff", "basedpyright", "doc8"]
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+pattern = "default-unprefixed"
+
+[tool.hatch.build.targets.sdist]
+include = ["procrastinate"]
+exclude = ["procrastinate/demos"]
+
+[tool.hatch.build.targets.wheel]
+exclude = ["procrastinate/demos"]
+
+[tool.uv]
+cache-keys = [{ git = { commit = true, tags = true } }]
+required-version = ">=0.5.21"
+default-groups = ["release", "lint_format", "pg_implem", "test", "docs"]
 
 [tool.pytest.ini_options]
 addopts = ["-vv", "--strict-markers", "-rfE", "--reuse-db", "-m not benchmark"]


### PR DESCRIPTION
## Summary

Tidies up `pyproject.toml` to silence two TOML linter warnings, with no change to effective configuration.

- **Reorder sections** so all `[tool.*]` tables are contiguous (`[build-system]` → `[project]` + subtables → `[dependency-groups]` → all `[tool.*]`). Previously the `tool` super-table was split by `[project]` and `[dependency-groups]`, triggering "Defining tables out-of-order is discouraged". Pure reordering — parsing before and after yields identical data.
- **Rename `tool.ruff.lint.extend-ignore` → `ignore`**. `extend-ignore` is a deprecated alias; `ignore` now has identical additive behavior.

## Verification

- Both versions parse to deep-equal data structures (only ordering changed).
- `ruff check` runs clean with the renamed key (no new violations).
- Pre-commit hooks (incl. `check toml`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized project configuration sections for better structure.
  * Updated linting rule application settings to refine code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->