### PR TITLE
contrib/django: auto-close Django DB connections around each task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 build
 dist
 docs/_build
+docs/superpowers
 htmlcov
 VERSION.txt
 .benchmarks

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "superpowers"]
 
 # If we don't do that, glossary checks are case sensitive.
 # https://github.com/sphinx-doc/sphinx/issues/7418

--- a/docs/howto/django/basic_usage.md
+++ b/docs/howto/django/basic_usage.md
@@ -53,6 +53,34 @@ in Django's settings (see {doc}`logs`).
 See {doc}`../basics/command_line` for more details on the CLI.
 If you prefer writing your own scripts, see {doc}`scripts`.
 
+## Database connections
+
+The worker manages Django's database connections around each task the same way
+Django does around an HTTP request: per-thread connections are closed before and
+after every task (sync or async) via `close_old_connections()`, and Django's
+query log (only populated under `DEBUG=True`) is cleared with `reset_queries()`.
+So for an ordinary task you don't have to do anything — the connection it opens is
+cleaned up at the task boundaries, and `CONN_MAX_AGE` is respected, so persistent
+connections are reused between tasks rather than force-closed.
+
+The one case this doesn't cover is *within* a single long-running task: the worker
+only closes at task boundaries, so a connection opened early stays open until the
+task finishes, even across a long stretch of non-database work. That holds a
+connection slot for the whole task and risks the idle connection being dropped
+before a later query. If that matters, close it from within the task once you're
+done with the database for a while:
+
+```python
+from django.db import close_old_connections
+
+@app.task
+def long_task():
+    do_early_db_work()
+    close_old_connections()  # release the connection before the long idle stretch
+    do_hours_of_non_db_work()
+    do_late_db_work()  # reconnects fresh
+```
+
 ## Deferring jobs
 
 Defer jobs from your views works as you would expect:

--- a/docs/howto/django/tests.md
+++ b/docs/howto/django/tests.md
@@ -81,10 +81,10 @@ make this task available even after the test has run. You probably want to
 avoid this, for example by creating a new app within each of those tests:
 
 ```python
-from procrastinate.contrib.django import app
+from procrastinate.contrib.django import DjangoApp, app
 
 def test_my_task():
-    new_app = procrastinate_app.ProcrastinateApp(app.connector)
+    new_app = DjangoApp(connector=app.connector)
 
     @new_app.task
     def my_task(a, b):
@@ -93,6 +93,11 @@ def test_my_task():
     my_task.defer(a=1, b=2)
     ...
 ```
+
+Use {py:class}`~procrastinate.contrib.django.DjangoApp` (the same app class the
+contrib uses) rather than a bare {py:class}`procrastinate.App`, so that tasks run by
+a worker get the automatic connection cleanup described in {doc}`basic_usage` and
+don't leak connections at test database teardown.
 
 :::
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -110,6 +110,8 @@ Django
 
 .. automodule:: procrastinate.contrib.django
 
+.. autoclass:: procrastinate.contrib.django.DjangoApp
+
 
 SQLAlchemy
 ----------

--- a/procrastinate/contrib/django/__init__.py
+++ b/procrastinate/contrib/django/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from .db_cleanup import DjangoApp
 from .procrastinate_app import app
 from .utils import connector_params
 
 __all__ = [
+    "DjangoApp",
     "app",
     "connector_params",
 ]

--- a/procrastinate/contrib/django/apps.py
+++ b/procrastinate/contrib/django/apps.py
@@ -7,7 +7,7 @@ from django.utils import module_loading
 
 import procrastinate
 
-from . import django_connector, procrastinate_app, settings
+from . import db_cleanup, django_connector, procrastinate_app, settings
 
 
 class ProcrastinateConfig(apps.AppConfig):
@@ -38,7 +38,7 @@ def create_app(blueprint: procrastinate.Blueprint) -> procrastinate.App:
     connector = django_connector.DjangoConnector(
         alias=settings.settings.DATABASE_ALIAS,
     )
-    app = procrastinate.App(
+    app = db_cleanup.DjangoApp(
         connector=connector,
         import_paths=list(get_import_paths()),
         worker_defaults=settings.settings.WORKER_DEFAULTS,

--- a/procrastinate/contrib/django/db_cleanup.py
+++ b/procrastinate/contrib/django/db_cleanup.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from asgiref import sync as asgiref_sync
+from django.db import close_old_connections, reset_queries
+
+from procrastinate import app as app_module
+
+if TYPE_CHECKING:
+    from procrastinate import job_context, worker
+    from procrastinate.app import WorkerOptions
+    from procrastinate.middleware import AsyncCallNext, SyncCallNext
+
+
+def _cleanup_before() -> None:
+    # Drop a persistent connection (CONN_MAX_AGE > 0) that may have died while the
+    # worker pool thread was idle between tasks, so the task transparently
+    # reconnects instead of failing on a dead socket. CONN_MAX_AGE is respected:
+    # a healthy persistent connection is kept.
+    close_old_connections()
+
+
+def _cleanup_after() -> None:
+    # Don't leak the connection past the unit of work...
+    close_old_connections()
+    # ...and clear Django's per-connection query log. It is only populated when
+    # settings.DEBUG is True (and closing the connection does not clear it, since
+    # the log lives on the persistent connection wrapper), so without this a
+    # worker run with DEBUG=True slowly accumulates it. A no-op when DEBUG is False.
+    reset_queries()
+
+
+def close_db_connections(
+    call_next: SyncCallNext,
+    context: job_context.JobContext,
+    worker: worker.Worker,
+) -> Any:
+    """
+    Sync task middleware that manages Django's per-thread DB connections around a
+    sync task, the same way Django manages them around an HTTP request.
+
+    Runs in the worker's asgiref ``sync_to_async`` pool thread — the same thread
+    Django opened its per-thread connection in — so closing here targets the right
+    connection. Without it, the connection opened by a sync ORM call leaks for the
+    lifetime of the (reused) pool thread.
+
+    Note: for the rare sync function that returns an awaitable without being a
+    coroutine function (awaited later by the worker), the after-cleanup runs after
+    the sync portion returns the awaitable, not after it is awaited. That edge case
+    is out of scope here.
+    """
+    _cleanup_before()
+    try:
+        return call_next()
+    finally:
+        _cleanup_after()
+
+
+# close_old_connections() is @async_unsafe, so the async middleware must not call
+# it on the event loop. Route it through sync_to_async(thread_sensitive=True) so it
+# runs in Django's thread-sensitive context (the same context the async ORM used).
+_cleanup_before_async = asgiref_sync.sync_to_async(
+    _cleanup_before, thread_sensitive=True
+)
+_cleanup_after_async = asgiref_sync.sync_to_async(_cleanup_after, thread_sensitive=True)
+
+
+async def close_db_connections_async(
+    call_next: AsyncCallNext,
+    context: job_context.JobContext,
+    worker: worker.Worker,
+) -> Any:
+    """
+    Async task middleware that manages Django's per-thread DB connections around an
+    async task. Mirrors :func:`close_db_connections` but runs the cleanup via
+    ``sync_to_async`` because the async task runs on the event loop and
+    ``close_old_connections`` is ``@async_unsafe``.
+    """
+    await _cleanup_before_async()
+    try:
+        return await call_next()
+    finally:
+        await _cleanup_after_async()
+
+
+def with_db_cleanup(worker_defaults: WorkerOptions | None) -> WorkerOptions:
+    """
+    Return a copy of ``worker_defaults`` with the Django DB-cleanup middlewares
+    prepended to ``task_middleware``. Ours go first so they sit *outermost*, around
+    any user-supplied worker-wide middleware. The worker kind-filters them per task,
+    so each task gets exactly the matching one.
+    """
+    base: WorkerOptions = worker_defaults or {}
+    existing = list(base.get("task_middleware") or [])
+    result: WorkerOptions = {
+        **base,
+        "task_middleware": [
+            close_db_connections,
+            close_db_connections_async,
+            *existing,
+        ],
+    }
+    return result
+
+
+class DjangoApp(app_module.App):
+    """
+    A :class:`procrastinate.App` preconfigured to manage Django's per-thread
+    database connections around each task (see :func:`close_db_connections`).
+
+    This is the app the Django contrib runs (``procrastinate.contrib.django.app``).
+    It is also the app to use when building a throwaway app in a test — e.g. to
+    avoid leaving a task registered on the global app — so that tasks run by a
+    worker get the same connection cleanup and don't leak connections at test
+    database teardown::
+
+        from procrastinate.contrib.django import DjangoApp, app
+
+        new_app = DjangoApp(connector=app.connector)
+
+    The cleanup is configured by merging the DB-cleanup middlewares into
+    ``worker_defaults`` (see :func:`with_db_cleanup`); any ``worker_defaults`` you
+    pass are preserved.
+    """
+
+    def __init__(
+        self, *, worker_defaults: WorkerOptions | None = None, **kwargs: Any
+    ) -> None:
+        super().__init__(worker_defaults=with_db_cleanup(worker_defaults), **kwargs)

--- a/tests/integration/contrib/django/test_db_cleanup.py
+++ b/tests/integration/contrib/django/test_db_cleanup.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from django.db import connection
+
+import procrastinate.contrib.django
+from procrastinate.contrib.django import models
+
+
+def count_other_sessions() -> int:
+    """
+    Number of sessions on the test database other than the test's own connection.
+    A connection leaked by a worker thread (a different thread than the test) is
+    invisible to Django's thread-local cache but shows up here, because
+    pg_stat_activity is server-side and global.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+        )
+        return cursor.fetchone()[0]
+
+
+def assert_no_leaked_session(before: int, timeout: float = 10.0) -> None:
+    """
+    Assert the worker run didn't leak a session, tolerating transient sessions.
+
+    The worker uses its own psycopg connection pool (listen/notify) whose
+    connections are torn down asynchronously when the worker stops, so right after
+    run_worker_once() the count can still be briefly elevated. A *real* per-thread
+    Django ORM leak never goes away (the asgiref worker thread persists holding it),
+    so poll until the transient pool sessions drain: a leak never settles and the
+    assertion fails at the deadline.
+    """
+    deadline = time.monotonic() + timeout
+    while count_other_sessions() > before and time.monotonic() < deadline:
+        time.sleep(0.1)
+    assert count_other_sessions() <= before
+
+
+def run_worker_once() -> None:
+    app = procrastinate.contrib.django.app
+
+    async def run() -> None:
+        # The Django connector can't listen/notify, so the worker uses a separate
+        # async connector whose own pool is closed when open_async() exits.
+        with app.replace_connector(app.connector.get_worker_connector()) as worker_app:
+            async with worker_app.open_async():
+                await worker_app.run_worker_async(
+                    wait=False,
+                    install_signal_handlers=False,
+                    listen_notify=False,
+                )
+
+    asyncio.run(run())
+
+
+# transaction=True so the deferred job is actually committed and visible to the
+# worker's separate connection (a transaction-rollback test would hide it and the
+# worker would process nothing, passing vacuously).
+@pytest.mark.django_db(transaction=True)
+def test_sync_task_does_not_leak_db_connections():
+    app = procrastinate.contrib.django.app
+
+    @app.task(name="test_db_cleanup_sync_task")
+    def sync_task():
+        # Sync ORM call: opens a per-thread Django connection in the worker thread.
+        list(models.ProcrastinateJob.objects.all())
+
+    sync_task.defer()
+
+    before = count_other_sessions()
+    run_worker_once()
+    assert_no_leaked_session(before)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_async_task_does_not_leak_db_connections():
+    app = procrastinate.contrib.django.app
+
+    @app.task(name="test_db_cleanup_async_task")
+    async def async_task():
+        # Async ORM call.
+        await models.ProcrastinateJob.objects.acount()
+
+    async_task.defer()
+
+    before = count_other_sessions()
+    run_worker_once()
+    assert_no_leaked_session(before)

--- a/tests/unit/contrib/django/test_db_cleanup.py
+++ b/tests/unit/contrib/django/test_db_cleanup.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import pytest
+
+from procrastinate import blueprints, middleware, testing
+from procrastinate.contrib.django import db_cleanup
+
+
+def test_sync_middleware_closes_before_and_after(mocker):
+    events = []
+    mocker.patch.object(
+        db_cleanup, "close_old_connections", side_effect=lambda: events.append("close")
+    )
+    # reset_queries clears the (DEBUG-only) query log and runs only after the task.
+    mocker.patch.object(
+        db_cleanup, "reset_queries", side_effect=lambda: events.append("reset")
+    )
+
+    def call_next():
+        events.append("run")
+        return "result"
+
+    result = db_cleanup.close_db_connections(call_next, context=None, worker=None)
+
+    assert result == "result"
+    assert events == ["close", "run", "close", "reset"]
+
+
+def test_sync_middleware_cleans_up_even_on_error(mocker):
+    close = mocker.patch.object(db_cleanup, "close_old_connections")
+    reset = mocker.patch.object(db_cleanup, "reset_queries")
+
+    def call_next():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        db_cleanup.close_db_connections(call_next, context=None, worker=None)
+
+    # before + after close, and the after-task reset, all still happen.
+    assert close.call_count == 2
+    assert reset.call_count == 1
+
+
+async def test_async_middleware_closes_before_and_after(mocker):
+    events = []
+    # Patch the underlying sync functions. The async middleware routes them through
+    # asgiref.sync_to_async, so a thread runs them — appends still happen in order
+    # relative to the awaited call_next.
+    mocker.patch.object(
+        db_cleanup, "close_old_connections", side_effect=lambda: events.append("close")
+    )
+    mocker.patch.object(
+        db_cleanup, "reset_queries", side_effect=lambda: events.append("reset")
+    )
+
+    async def call_next():
+        events.append("run")
+        return "result"
+
+    result = await db_cleanup.close_db_connections_async(
+        call_next, context=None, worker=None
+    )
+
+    assert result == "result"
+    assert events == ["close", "run", "close", "reset"]
+
+
+async def test_async_middleware_cleans_up_even_on_error(mocker):
+    close = mocker.patch.object(db_cleanup, "close_old_connections")
+    reset = mocker.patch.object(db_cleanup, "reset_queries")
+
+    async def call_next():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        await db_cleanup.close_db_connections_async(
+            call_next, context=None, worker=None
+        )
+
+    # before + after close, and the after-task reset, all still happen.
+    assert close.call_count == 2
+    assert reset.call_count == 1
+
+
+def test_middleware_kinds_are_detected_correctly():
+    # The worker filters worker-wide middleware by kind per task: the sync one must
+    # be seen as sync (wraps sync tasks), the async one as async (wraps async tasks).
+    assert middleware.is_async_middleware(db_cleanup.close_db_connections) is False
+    assert middleware.is_async_middleware(db_cleanup.close_db_connections_async) is True
+
+
+def test_with_db_cleanup_prepends_both_middlewares():
+    result = db_cleanup.with_db_cleanup(None)
+    assert result["task_middleware"] == [
+        db_cleanup.close_db_connections,
+        db_cleanup.close_db_connections_async,
+    ]
+
+
+def test_with_db_cleanup_preserves_user_task_middleware():
+    def user_mw(call_next, context, worker):
+        return call_next()
+
+    original = {"task_middleware": [user_mw], "concurrency": 5}
+    result = db_cleanup.with_db_cleanup(original)
+
+    # User middleware is kept, after ours (ours outermost); other keys untouched.
+    assert result["task_middleware"] == [
+        db_cleanup.close_db_connections,
+        db_cleanup.close_db_connections_async,
+        user_mw,
+    ]
+    assert result["concurrency"] == 5
+    # The input dict is not mutated.
+    assert original["task_middleware"] == [user_mw]
+
+
+def test_create_app_wires_db_cleanup_into_worker_defaults():
+    from procrastinate.contrib.django import apps
+
+    app = apps.create_app(blueprint=blueprints.Blueprint())
+
+    assert isinstance(app, db_cleanup.DjangoApp)
+    task_middleware = app.worker_defaults["task_middleware"]
+    assert db_cleanup.close_db_connections in task_middleware
+    assert db_cleanup.close_db_connections_async in task_middleware
+
+
+def test_django_app_merges_db_cleanup_into_worker_defaults():
+    app = db_cleanup.DjangoApp(connector=testing.InMemoryConnector())
+
+    assert app.worker_defaults["task_middleware"] == [
+        db_cleanup.close_db_connections,
+        db_cleanup.close_db_connections_async,
+    ]
+
+
+def test_django_app_preserves_user_worker_defaults():
+    def user_mw(call_next, context, worker):
+        return call_next()
+
+    app = db_cleanup.DjangoApp(
+        connector=testing.InMemoryConnector(),
+        worker_defaults={"task_middleware": [user_mw], "concurrency": 5},
+    )
+
+    # User middleware kept (after ours, which stay outermost); other keys untouched.
+    assert app.worker_defaults["task_middleware"] == [
+        db_cleanup.close_db_connections,
+        db_cleanup.close_db_connections_async,
+        user_mw,
+    ]
+    assert app.worker_defaults["concurrency"] == 5
+
+
+def test_django_app_is_publicly_exported():
+    # Users build a throwaway DjangoApp in tests (see howto/django/tests); it must
+    # be importable from the package.
+    from procrastinate.contrib.django import DjangoApp
+
+    assert DjangoApp is db_cleanup.DjangoApp


### PR DESCRIPTION
## What

When a Procrastinate task uses the Django ORM, the per-thread Django DB connection opened to run it was never closed. Long-running workers accumulate connections; tests fail at teardown with `database "..." is being accessed by other users`. This now closes both sync and async tasks' connections around each task, the way Django does around a request — `close_old_connections()` before and after, plus `reset_queries()` after to clear the DEBUG-only query log. `CONN_MAX_AGE` is respected.

## How

Built on the task middleware feature, **not** by monkey-patching `task.func`:

- **sync middleware** runs in the worker's asgiref `sync_to_async` pool thread — the same thread Django opened its per-thread connection in — and closes directly;
- **async middleware** routes cleanup through `sync_to_async(thread_sensitive=True)`, since `close_old_connections()` is `@async_unsafe`.

Both are registered worker-wide via `worker_defaults`. The worker kind-filters worker-wide middleware per task, so each task gets exactly the matching one (sync→sync, async→async), wrapping outermost.

## Why a `DjangoApp` class

The cleanup is configured in `worker_defaults`, which only the contrib's own app (built in `create_app`) receives. But the documented way to avoid leaking task registrations across tests is to build a **separate** throwaway app — and a bare `procrastinate.App(connector=app.connector)` would silently lack the cleanup, re-introducing the connection leak as soon as that app runs a worker.

`DjangoApp(procrastinate.App)` fixes this: its `__init__` merges the cleanup middlewares into `worker_defaults`, so `DjangoApp(connector=app.connector)` is an isolated, correctly-configured app. `create_app` builds it too. It does **no** monkey-patching and no registration hooks — just one override of a stable public constructor param (`worker_defaults`).

## Tests

- **Unit**: middleware before/after + on-error (sync & async), kind detection, `with_db_cleanup` merge/ordering/non-mutation, `DjangoApp` wiring + public export.
- **Integration**: defer a sync/async ORM task, run the worker once, assert no net `pg_stat_activity` session leak. Verified **red-first** (fails with a leaked session, incl. the exact teardown error, against the unwired code).

## Notes

- Alternative implementation to #1555 — same behavior and public `DjangoApp` surface, but middleware-based rather than wrapping `task.func`.
- Closes #1551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DjangoApp` for Django integration with automatic database connection cleanup during task execution.

* **Documentation**
  * Added database connection management guide for Django workers.
  * Updated Django integration test documentation to reference the new app class.
  * Added API reference documentation for the new app class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->