### PR TITLE
Deflake test_polling

### DIFF
--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -250,6 +250,8 @@ async def test_concurrency(async_app: app_module.App):
 
 
 async def test_polling(async_app: app_module.App):
+    polling_interval = 0.5
+
     @async_app.task(queue="default", name="sum")
     async def sum(a: int, b: int):
         return a + b
@@ -260,26 +262,24 @@ async def test_polling(async_app: app_module.App):
             concurrency=1,
             wait=True,
             listen_notify=False,
-            fetch_job_polling_interval=0.3,
+            fetch_job_polling_interval=polling_interval,
         )
     )
 
-    # long enough for worker to wait until next polling
-    await asyncio.sleep(0.1)
+    # Process a warm-up job to confirm the worker is up and now idle between polls.
+    warmup_id = await sum.defer_async(a=1, b=1)
+    await wait_for_job_status(async_app, warmup_id, Status.SUCCEEDED)
+    # Let the worker's immediate post-job poll pass before deferring our job.
+    await asyncio.sleep(polling_interval / 5)
 
     job_id = await sum.defer_async(a=5, b=4)
 
-    await asyncio.sleep(0.1)
-
+    # Still within the polling interval: the job must not be fetched yet.
+    await asyncio.sleep(polling_interval / 3)
     job_status = await async_app.job_manager.get_job_status_async(job_id=job_id)
-
     assert job_status == Status.TODO, "Job fetched faster than expected."
 
-    await asyncio.sleep(0.2)
-
-    job_status = await async_app.job_manager.get_job_status_async(job_id=job_id)
-
-    assert job_status == Status.SUCCEEDED, "Job should have been fetched and processed."
+    await wait_for_job_status(async_app, job_id, Status.SUCCEEDED)
 
     try:
         worker_task.cancel()


### PR DESCRIPTION
## What

De-flakes `tests/acceptance/test_async.py::test_polling`, which intermittently fails on CI with:

```
AssertionError: Job fetched faster than expected.
assert <Status.SUCCEEDED: 'succeeded'> == <Status.TODO: 'todo'>
```

(seen most recently on the `py3.11` job of an unrelated Renovate PR).

## Root cause

The test deferred a job and asserted it was still `TODO` shortly after, relying on a fixed `asyncio.sleep(0.1)` to wait out worker startup first. Worker startup is several DB round-trips (`prune_stalled_workers` + `register_worker` + first poll). When that exceeds the fixed sleep on a slow/busy runner, the worker's *first* poll lands *after* the job is deferred and fetches it immediately, so the job is already `SUCCEEDED` by the time we check.

Reproduced deterministically by injecting 0.15s of latency into `register_worker`: 0s passes, 0.15s fails with the exact CI error.

## Fix

Synchronize on the actual condition instead of guessing a duration:

- Process a **warm-up job** and wait for it to reach `SUCCEEDED` (via the existing `wait_for_job_status` helper) — this confirms the worker is up and idle between polls.
- A short `sleep(interval/5)` lets the worker's immediate post-job poll pass before we defer the measured job (this is a second, narrower race that only showed up under CPU saturation).
- Defer the measured job, assert it's still `TODO` within the interval, then wait for `SUCCEEDED`.
- Bumped the polling interval `0.3` → `0.5` for comfortable margin.

## Verification

Green quiet, under 3×nproc CPU load, and across injected startup latencies up to 0.8s (8× the threshold that broke the old test). Full `test_async.py` passes; ruff check/format and pre-commit clean.

Refs #1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved async polling test reliability with timing-driven assertions and enhanced warm-up procedures to better validate job status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->