### PR TITLE
Add worker middleware

### DIFF
--- a/docs/howto/advanced/middleware.md
+++ b/docs/howto/advanced/middleware.md
@@ -99,8 +99,9 @@ async def otel_mw(call_next, context, worker):
 app.run_worker(worker_middleware=[otel_mw])
 ```
 
-It can also be set on `worker_defaults`. A non-async or non-callable entry raises
-`TypeError` when the worker is created.
+It can also be set on `worker_defaults`. When the worker is created, a non-callable
+entry raises `TypeError`, and a sync (non-async) entry raises
+{py:class}`~procrastinate.exceptions.MiddlewareKindMismatch`.
 
 A worker middleware is the **outermost** layer. For a given job the full chain is,
 outermost to innermost: worker middleware → worker-wide task middleware → per-task

--- a/docs/howto/advanced/middleware.md
+++ b/docs/howto/advanced/middleware.md
@@ -1,16 +1,30 @@
-# Add task middleware
+# Add middleware
 
-A *task middleware* wraps the execution of a task, letting you run code before and
-after it — for logging, dependency-injection scopes, resource cleanup, and so on.
+*Middleware* wraps the execution of your tasks, letting you run code before and
+after each one — for logging, tracing, dependency-injection scopes, resource
+cleanup, and so on.
 
-A middleware is a callable taking `(call_next, context, worker)`. It must call (or
-`await`) `call_next()` to run the next middleware — or the task itself — and return
-the result. `context` is the {py:class}`~procrastinate.JobContext`; `worker` is the
-running worker (you may call `worker.stop()` from it).
+Procrastinate has two kinds of middleware:
 
-## The sync/async rule
+- **Task middleware** runs *in the task's own execution context* — a sync
+  middleware in the task's worker thread, an async middleware on the event loop —
+  so it must match the task's sync/async nature. Register it per-task or
+  worker-wide.
+- **Worker middleware** is *always async* and wraps every job on the event loop,
+  both sync and async tasks. Register it worker-wide only.
 
-A middleware's nature must match the task it wraps:
+Both are callables taking `(call_next, context, worker)`. A middleware must call
+(or `await`) `call_next()` to run the next middleware — or the task itself — and
+return the result. `context` is the {py:class}`~procrastinate.JobContext`;
+`worker` is the running worker (you may call `worker.stop()` from it).
+
+## Task middleware
+
+A task middleware wraps a task's execution in the task's own context.
+
+### The sync/async rule
+
+A task middleware's nature must match the task it wraps:
 
 - a **sync** task takes **sync** middleware (a plain `def`), which runs in the
   task's worker thread;
@@ -39,7 +53,7 @@ A middleware's kind is detected with {py:func}`inspect.iscoroutinefunction`: if
 you build a middleware out of wrappers or decorators, keep the outermost
 callable an `async def` for it to count as async middleware.
 
-## Per-task middleware
+### Per-task middleware
 
 ```python
 @app.task(task_middleware=[log_mw])
@@ -51,44 +65,24 @@ A mismatch (an async middleware on a sync task, or vice versa) raises
 {py:class}`~procrastinate.exceptions.MiddlewareKindMismatch` when the task is
 declared.
 
-## Worker-wide middleware
+### Worker-wide task middleware
 
-Apply middleware to every task a worker runs:
+Apply task middleware to every task a worker runs:
 
 ```python
 app.run_worker(task_middleware=[log_mw, async_log_mw])
 ```
 
-Worker-wide middleware is **filtered by kind** per task: the sync ones wrap sync
-tasks, the async ones wrap async tasks. To cover both kinds, pass one of each (as
-above). Worker-wide middleware wraps *around* any per-task middleware.
+Worker-wide task middleware is **filtered by kind** per task: the sync ones wrap
+sync tasks, the async ones wrap async tasks. To cover both kinds, pass one of each
+(as above). Worker-wide task middleware wraps *around* any per-task middleware.
 
-## Ordering
+### Ordering
 
-For a given task, the chain is, outermost to innermost: worker-wide middleware (in
-list order) → per-task middleware (in list order) → the task function. The first
-middleware in a list runs its "before" code first and its "after" code last.
-
-## Middleware and task failures
-
-Exceptions raised by the task (or by an inner middleware) flow through the
-chain to the worker, which uses them to decide the job's final status: retries,
-failure, and abortion ({py:class}`~procrastinate.exceptions.JobAborted`) all
-rely on the exception reaching the worker. A middleware that swallows
-exceptions (e.g. with a bare `except Exception:`) would mark the job succeeded,
-skip retries, and ignore abort requests — run cleanup code in a `try`/`finally`
-block and always re-raise.
-
-## Stopping the worker
-
-A middleware can stop the worker (after currently-running jobs finish, subject
-to `shutdown_graceful_timeout`):
-
-```python
-def stop_after_one(call_next, context, worker):
-    worker.stop()
-    return call_next()
-```
+For a given task, the task-middleware chain is, outermost to innermost: worker-wide
+task middleware (in list order) → per-task middleware (in list order) → the task
+function. The first middleware in a list runs its "before" code first and its
+"after" code last.
 
 ## Worker middleware
 
@@ -108,19 +102,39 @@ app.run_worker(worker_middleware=[otel_mw])
 It can also be set on `worker_defaults`. A non-async or non-callable entry raises
 `TypeError` when the worker is created.
 
-A worker middleware is the **outermost** layer: for a given job the chain is, outermost
-to innermost, worker middleware → worker-wide task middleware → per-task task
-middleware → the task. The same failure rule applies — run cleanup in `try`/`finally`
-and re-raise, or you break retries and abort.
+A worker middleware is the **outermost** layer. For a given job the full chain is,
+outermost to innermost: worker middleware → worker-wide task middleware → per-task
+task middleware → the task.
 
 ### Worker middleware vs. worker-wide task middleware
 
 Both are registered on the worker, so pick by what you need:
 
-- **Worker middleware** (`worker_middleware=`) — always async, runs on the event loop,
-  wraps every task uniformly (sync and async). Use it to wrap a job in async code: a
-  tracing span, an `async with`, async metrics.
+- **Worker middleware** (`worker_middleware=`) — always async, runs on the event
+  loop, wraps every task uniformly (sync and async). Use it to wrap a job in async
+  code: a tracing span, an `async with`, async metrics.
 - **Worker-wide task middleware** (`task_middleware=`) — runs *in the task's own
-  context* (a sync middleware in the task's worker thread) and is kind-matched. Use it
-  to manage thread-local resources around a sync task (e.g. closing Django DB
+  context* (a sync middleware in the task's worker thread) and is kind-matched. Use
+  it to manage thread-local resources around a sync task (e.g. closing Django DB
   connections).
+
+## Failures and retries
+
+This applies to **both** task and worker middleware. Exceptions raised by the task
+(or by an inner middleware) flow through the chain to the worker, which uses them to
+decide the job's final status: retries, failure, and abortion
+({py:class}`~procrastinate.exceptions.JobAborted`) all rely on the exception
+reaching the worker. A middleware that swallows exceptions (e.g. with a bare
+`except Exception:`) would mark the job succeeded, skip retries, and ignore abort
+requests — run cleanup code in a `try`/`finally` block and always re-raise.
+
+## Stopping the worker
+
+Any middleware can stop the worker (after currently-running jobs finish, subject
+to `shutdown_graceful_timeout`) by calling `worker.stop()`:
+
+```python
+def stop_after_one(call_next, context, worker):
+    worker.stop()
+    return call_next()
+```

--- a/docs/howto/advanced/middleware.md
+++ b/docs/howto/advanced/middleware.md
@@ -114,9 +114,11 @@ Both are registered on the worker, so pick by what you need:
   loop, wraps every task uniformly (sync and async). Use it to wrap a job in async
   code: a tracing span, an `async with`, async metrics.
 - **Worker-wide task middleware** (`task_middleware=`) — runs *in the task's own
-  context* (a sync middleware in the task's worker thread) and is kind-matched. Use
-  it to manage thread-local resources around a sync task (e.g. closing Django DB
-  connections).
+  context* (a sync middleware in the task's worker thread) and is kind-matched.
+  Running in the task's thread is what lets it manage thread-local state around a
+  sync task. This is how Procrastinate's {doc}`Django integration
+  <../django/basic_usage>` closes Django's per-thread DB connections after each
+  task.
 
 ## Failures and retries
 

--- a/docs/howto/advanced/middleware.md
+++ b/docs/howto/advanced/middleware.md
@@ -90,8 +90,37 @@ def stop_after_one(call_next, context, worker):
     return call_next()
 ```
 
-:::{note}
-Task middleware as described here runs in the task's own execution context.
-A *worker middleware* (running on the event loop, allowing `async with` /
-`await` around sync tasks) may be added in the future.
-:::
+## Worker middleware
+
+A *worker middleware* is **always async** and wraps every job a worker runs **on
+the event loop** — both sync and async tasks. (For a sync task, `await call_next()`
+drives the task's worker-thread hop internally.) Unlike task middleware there is no
+sync/async kind to match, and it is registered **worker-wide only**.
+
+```python
+async def otel_mw(call_next, context, worker):
+    with tracer.start_as_current_span(f"run/{context.task.name}"):
+        return await call_next()   # the task's exception propagates → span records it
+
+app.run_worker(worker_middleware=[otel_mw])
+```
+
+It can also be set on `worker_defaults`. A non-async or non-callable entry raises
+`TypeError` when the worker is created.
+
+A worker middleware is the **outermost** layer: for a given job the chain is, outermost
+to innermost, worker middleware → worker-wide task middleware → per-task task
+middleware → the task. The same failure rule applies — run cleanup in `try`/`finally`
+and re-raise, or you break retries and abort.
+
+### Worker middleware vs. worker-wide task middleware
+
+Both are registered on the worker, so pick by what you need:
+
+- **Worker middleware** (`worker_middleware=`) — always async, runs on the event loop,
+  wraps every task uniformly (sync and async). Use it to wrap a job in async code: a
+  tracing span, an `async with`, async metrics.
+- **Worker-wide task middleware** (`task_middleware=`) — runs *in the task's own
+  context* (a sync middleware in the task's worker thread) and is kind-matched. Use it
+  to manage thread-local resources around a sync task (e.g. closing Django DB
+  connections).

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -38,7 +38,7 @@ Middleware
 ----------
 
 .. automodule:: procrastinate.middleware
-    :members: TaskMiddleware
+    :members: TaskMiddleware, WorkerMiddleware
     :no-value:
 
 Registering a task middleware whose sync/async nature doesn't match the task

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -41,8 +41,8 @@ Middleware
     :members: TaskMiddleware, WorkerMiddleware
     :no-value:
 
-Registering a task middleware whose sync/async nature doesn't match the task
-raises `MiddlewareKindMismatch`.
+Registering a *task* middleware whose sync/async nature doesn't match the task
+raises `MiddlewareKindMismatch` (worker middleware, being always async, is exempt).
 
 Blueprints
 ----------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -42,7 +42,7 @@ Middleware
     :no-value:
 
 Registering a *task* middleware whose sync/async nature doesn't match the task
-raises `MiddlewareKindMismatch` (worker middleware, being always async, is exempt).
+or a *worker* middleware that isn't async raises `MiddlewareKindMismatch`.
 
 Blueprints
 ----------

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -45,6 +45,7 @@ class WorkerOptions(TypedDict):
     update_heartbeat_interval: NotRequired[float]
     stalled_worker_timeout: NotRequired[float]
     task_middleware: NotRequired[list[middleware.TaskMiddleware]]
+    worker_middleware: NotRequired[list[middleware.WorkerMiddleware]]
 
 
 class App(blueprints.Blueprint):
@@ -337,6 +338,10 @@ class App(blueprints.Blueprint):
             A list of middlewares wrapping every task this worker runs. Sync
             middlewares apply to sync tasks, async middlewares to async tasks.
             See `howto/advanced/middleware`. (defaults to no middleware)
+        worker_middleware: ``Optional[list[WorkerMiddleware]]``
+            A list of always-async middlewares wrapping every job this worker runs,
+            on the event loop (both sync and async tasks). See
+            `howto/advanced/middleware`. (defaults to no middleware)
         """
         self.perform_import_paths()
         worker = self._worker(**kwargs)

--- a/procrastinate/middleware.py
+++ b/procrastinate/middleware.py
@@ -9,11 +9,10 @@ if TYPE_CHECKING:
     from procrastinate import job_context, worker
 
 # A sync task middleware wraps a sync task (and runs in the task's worker thread);
-# an async task middleware wraps an async task (and runs on the event loop).
-#
-# (A future "worker middleware" — always-async, wrapping the whole job on the loop
-# — will be added to this module with its own ``WorkerMiddleware`` type. The
-# ``compose`` and ``is_async_middleware`` helpers below are generic and shared.)
+# an async task middleware wraps an async task (and runs on the event loop). A
+# worker middleware (below) is always async and wraps the whole job on the loop —
+# both sync and async tasks. The ``compose`` and ``is_async_middleware`` helpers
+# are generic and shared by both.
 SyncCallNext = Callable[[], Any]
 AsyncCallNext = Callable[[], Awaitable[Any]]
 SyncTaskMiddleware = Callable[
@@ -30,6 +29,13 @@ AsyncTaskMiddleware = Callable[
 #: (plain ``def``) wrap sync tasks; async middlewares (``async def``) wrap async
 #: tasks. See :doc:`/howto/advanced/middleware`.
 TaskMiddleware = SyncTaskMiddleware | AsyncTaskMiddleware
+#: A worker middleware wraps the execution of every job a worker runs, on the
+#: event loop. It is a callable taking ``(call_next, context, worker)`` and must
+#: be ``async def``. Unlike a task middleware it is always async and wraps both
+#: sync and async tasks. See :doc:`/howto/advanced/middleware`.
+WorkerMiddleware = Callable[
+    [AsyncCallNext, "job_context.JobContext", "worker.Worker"], Awaitable[Any]
+]
 
 
 def is_async_middleware(middleware: TaskMiddleware) -> bool:

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -48,6 +48,7 @@ class Worker:
         update_heartbeat_interval: float = 10.0,
         stalled_worker_timeout: float = 30.0,
         task_middleware: list[middleware.TaskMiddleware] | None = None,
+        worker_middleware: list[middleware.WorkerMiddleware] | None = None,
     ):
         self.app = app
         self.queues = queues
@@ -70,6 +71,17 @@ class Worker:
         for mw in self.task_middleware:
             if not callable(mw):
                 raise TypeError(f"Task middleware {mw!r} is not callable.")
+        self.worker_middleware: list[middleware.WorkerMiddleware] = (
+            worker_middleware or []
+        )
+        for mw in self.worker_middleware:
+            if not callable(mw):
+                raise TypeError(f"Worker middleware {mw!r} is not callable.")
+            if not middleware.is_async_middleware(mw):
+                raise TypeError(
+                    f"Worker middleware {mw!r} must be async (async def); "
+                    f"worker middleware always runs on the event loop."
+                )
 
         if self.worker_name:
             self.logger = logger.getChild(self.worker_name)

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -321,7 +321,12 @@ class Worker:
 
                 return task_result
 
-            job_result.result = await ensure_async()
+            async def run_job():
+                return await ensure_async()
+
+            job_result.result = await middleware.compose(
+                self.worker_middleware, run_job, context, self
+            )()
 
         except BaseException as e:
             exc_info = e

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -78,8 +78,9 @@ class Worker:
             if not callable(mw):
                 raise TypeError(f"Worker middleware {mw!r} is not callable.")
             if not middleware.is_async_middleware(mw):
-                raise TypeError(
-                    f"Worker middleware {mw!r} must be async (async def); "
+                mw_name = getattr(mw, "__name__", repr(mw))
+                raise exceptions.MiddlewareKindMismatch(
+                    f"Worker middleware {mw_name!r} must be async (async def); "
                     f"worker middleware always runs on the event loop."
                 )
 

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -456,6 +456,125 @@ async def test_stop_from_sync_task_middleware_stops_the_worker(app):
     assert len(processed) == 1
 
 
+async def test_worker_middleware_wraps_async_task(app):
+    order = []
+
+    async def mw(call_next, context, worker):
+        order.append("before")
+        result = await call_next()
+        order.append("after")
+        return result
+
+    @app.task(name="async_task")
+    async def async_task():
+        order.append("task")
+        return 42
+
+    await async_task.defer_async()
+    await app.run_worker_async(
+        wait=False, install_signal_handlers=False, worker_middleware=[mw]
+    )
+
+    assert order == ["before", "task", "after"]
+
+
+async def test_worker_middleware_wraps_sync_task(app):
+    # Headline capability: an always-async middleware wraps a SYNC task — an async
+    # task middleware cannot do this.
+    order = []
+
+    async def mw(call_next, context, worker):
+        order.append("before")
+        result = await call_next()
+        order.append("after")
+        return result
+
+    @app.task(name="sync_task")
+    def sync_task():
+        order.append("task")
+        return "ok"
+
+    await sync_task.defer_async()
+    await app.run_worker_async(
+        wait=False, install_signal_handlers=False, worker_middleware=[mw]
+    )
+
+    assert order == ["before", "task", "after"]
+
+
+async def test_worker_middleware_wraps_outside_task_middleware(app):
+    order = []
+
+    async def worker_mw(call_next, context, worker):
+        order.append("before:worker_mw")
+        result = await call_next()
+        order.append("after:worker_mw")
+        return result
+
+    async def per_task_mw(call_next, context, worker):
+        order.append("before:per_task")
+        result = await call_next()
+        order.append("after:per_task")
+        return result
+
+    @app.task(name="ordered", task_middleware=[per_task_mw])
+    async def ordered():
+        order.append("task")
+
+    await ordered.defer_async()
+    await app.run_worker_async(
+        wait=False, install_signal_handlers=False, worker_middleware=[worker_mw]
+    )
+
+    assert order == [
+        "before:worker_mw",
+        "before:per_task",
+        "task",
+        "after:per_task",
+        "after:worker_mw",
+    ]
+
+
+async def test_worker_middleware_can_transform_result(app):
+    seen = []
+
+    async def doubling_mw(call_next, context, worker):
+        return await call_next() * 2
+
+    async def recording_mw(call_next, context, worker):
+        result = await call_next()
+        seen.append(result)
+        return result
+
+    @app.task(name="returns_three")
+    async def returns_three():
+        return 3
+
+    job_id = await returns_three.defer_async()
+    # recording_mw is outermost, so it observes doubling_mw's transformation.
+    await app.run_worker_async(
+        wait=False,
+        install_signal_handlers=False,
+        worker_middleware=[recording_mw, doubling_mw],
+    )
+
+    assert seen == [6]
+    assert app.connector.jobs[job_id]["status"] == "succeeded"
+
+
+async def test_no_worker_middleware_runs_task_normally(app):
+    ran = []
+
+    @app.task(name="plain")
+    async def plain():
+        ran.append(True)
+
+    await plain.defer_async()
+    await app.run_worker_async(wait=False, install_signal_handlers=False)
+
+    assert ran == [True]
+
+
 async def test_task_middleware_from_worker_defaults_is_applied():
     # The middleware is configured on the App's worker_defaults (NOT passed to
     # run_worker), so it must reach the worker via the {**worker_defaults,

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -160,6 +160,32 @@ def test_worker_defaults_to_no_task_middleware(not_opened_app):
     assert worker.task_middleware == []
 
 
+def test_worker_defaults_to_no_worker_middleware(not_opened_app):
+    worker = Worker(not_opened_app)
+    assert worker.worker_middleware == []
+
+
+def test_worker_stores_worker_middleware(not_opened_app):
+    async def mw(call_next, context, worker):
+        return await call_next()
+
+    worker = Worker(not_opened_app, worker_middleware=[mw])
+    assert worker.worker_middleware == [mw]
+
+
+def test_worker_rejects_non_callable_worker_middleware(not_opened_app):
+    with pytest.raises(TypeError, match="not callable"):
+        Worker(not_opened_app, worker_middleware=["oops"])  # type: ignore[list-item]
+
+
+def test_worker_rejects_sync_worker_middleware(not_opened_app):
+    def sync_mw(call_next, context, worker):
+        return call_next()
+
+    with pytest.raises(TypeError, match="must be async"):
+        Worker(not_opened_app, worker_middleware=[sync_mw])  # type: ignore[list-item]
+
+
 async def test_sync_task_middleware_runs_in_the_task_thread(app):
     main_thread = threading.get_ident()
     seen = {}

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -182,7 +182,7 @@ def test_worker_rejects_sync_worker_middleware(not_opened_app):
     def sync_mw(call_next, context, worker):
         return call_next()
 
-    with pytest.raises(TypeError, match="must be async"):
+    with pytest.raises(exceptions.MiddlewareKindMismatch, match="must be async"):
         Worker(not_opened_app, worker_middleware=[sync_mw])  # type: ignore[list-item]
 
 

--- a/tests/unit/test_middleware.py
+++ b/tests/unit/test_middleware.py
@@ -599,3 +599,109 @@ async def test_task_middleware_from_worker_defaults_is_applied():
         await app.run_worker_async(wait=False, install_signal_handlers=False)
 
     assert seen == ["wd_task"]
+
+
+async def test_worker_middleware_exception_propagates_to_job_status(app):
+    async def passthrough_mw(call_next, context, worker):
+        return await call_next()
+
+    @app.task(name="boom")
+    async def boom():
+        raise ValueError("boom")
+
+    job_id = await boom.defer_async()
+    await app.run_worker_async(
+        wait=False, install_signal_handlers=False, worker_middleware=[passthrough_mw]
+    )
+
+    assert app.connector.jobs[job_id]["status"] == "failed"
+
+
+async def test_job_aborted_propagates_through_worker_middleware(app):
+    async def passthrough_mw(call_next, context, worker):
+        return await call_next()
+
+    @app.task(name="aborting")
+    async def aborting():
+        raise exceptions.JobAborted
+
+    job_id = await aborting.defer_async()
+    await app.run_worker_async(
+        wait=False, install_signal_handlers=False, worker_middleware=[passthrough_mw]
+    )
+
+    assert app.connector.jobs[job_id]["status"] == "aborted"
+
+
+async def test_retry_works_through_worker_middleware(app):
+    mw_calls = []
+
+    async def counting_mw(call_next, context, worker):
+        mw_calls.append(context.job.id)
+        return await call_next()
+
+    @app.task(name="flaky", retry=1)
+    async def flaky():
+        raise ValueError("nope")
+
+    job_id = await flaky.defer_async()
+    await app.run_worker_async(
+        wait=False, install_signal_handlers=False, worker_middleware=[counting_mw]
+    )
+
+    assert app.connector.jobs[job_id]["status"] == "failed"
+    assert app.connector.jobs[job_id]["attempts"] == 2
+    assert mw_calls == [job_id, job_id]
+
+
+async def test_stop_from_worker_middleware_stops_the_worker(app):
+    processed = []
+
+    async def stopping_mw(call_next, context, worker):
+        processed.append(context.job.id)
+        worker.stop()
+        return await call_next()
+
+    @app.task(name="stoppable")
+    async def stoppable():
+        return None
+
+    await stoppable.defer_async()
+    await stoppable.defer_async()
+
+    # wait=True would run forever unless stop() works; timeout so a failure fails
+    # rather than hangs.
+    await asyncio.wait_for(
+        app.run_worker_async(
+            wait=True, install_signal_handlers=False, worker_middleware=[stopping_mw]
+        ),
+        timeout=5,
+    )
+
+    # Concurrency is 1: stop() during the first job prevents the second from running.
+    assert len(processed) == 1
+
+
+async def test_worker_middleware_from_worker_defaults_is_applied():
+    # Configured on worker_defaults (NOT passed to run_worker), so it must reach the
+    # worker via the {**worker_defaults, **kwargs} merge — the Django-contrib path.
+    seen = []
+
+    async def record_mw(call_next, context, worker):
+        seen.append(context.task.name)
+        return await call_next()
+
+    app = App(
+        connector=testing.InMemoryConnector(),
+        worker_defaults={"worker_middleware": [record_mw]},
+    )
+    async with app.open_async():
+
+        @app.task(name="wd_task")
+        async def wd_task():
+            return None
+
+        await wd_task.defer_async()
+        await app.run_worker_async(wait=False, install_signal_handlers=False)
+
+    assert seen == ["wd_task"]


### PR DESCRIPTION
Implements the event-loop `worker_middleware` chain reserved as a follow-up in #1556. Builds on the task middleware from #1556 (which closed #1292).

## What

A **worker middleware**: an always-async callable `(call_next, context, worker)` that wraps every job's run on the event loop — both sync and async tasks — registered worker-wide only.

```python
async def otel_mw(call_next, context, worker):
    with tracer.start_as_current_span(f"run/{context.task.name}"):
        return await call_next()

app.run_worker(worker_middleware=[otel_mw])
```

Unlike task middleware, a single worker middleware wraps both sync and async tasks, so there's no sync/async kind-matching. The motivating case is OpenTelemetry-style tracing around every job without monkey-patching (#1027).

## Design

- **Boundary A — wraps the task run, not the bookkeeping.** Composed as the outermost layer around the task-middleware chain at the `ensure_async` call site in `Worker._process_job`, staying inside the existing `try/except/finally`. The task's exception propagates through `call_next`; status classification and the DB status write stay outside the middleware. (The alternative — wrapping `_process_job` incl. the status write — was rejected: it would overlap the future `job_processing_ended` hook and force a non-Pythonic outcome API, since `_process_job` swallows exceptions internally.)
- **Always async, worker-wide only.** Non-async / non-callable entries raise `TypeError` at worker construction. No per-task parameter, no `Task`/`Blueprint` changes.
- **`worker.stop()`**, not a `StopWorker` exception (already thread-safe/cooperative since #1556).
- **Nesting:** worker middleware → worker-wide task middleware → per-task task middleware → task.
- **No-op when unset**; reuses the generic `compose` / `is_async_middleware` from #1556 unchanged.

## Tests

`tests/unit/test_middleware.py`: wraps async task, wraps **sync** task (the headline), nests outside task middleware, result transform, exception→failed, `JobAborted`→aborted, retry-through-middleware, `stop()` from inside, `worker_defaults` injection, rejects sync/non-callable, no-op. Full unit suite 538 passing; ruff + basedpyright clean; docs `-W` clean.

## Docs

Restructured `docs/howto/advanced/middleware.md` to present task and worker middleware as parallel sections with a comparison; `WorkerMiddleware` added to the API reference.

## Follow-up (out of scope)

The worker **hooks** from #1308 (`before_fetching_job` for rate limiting; `job_processing_ended(JobResult)` for resolved-status observation) — complementary and deliberately separate. Keeping the middleware at boundary A keeps the hooks orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added worker-level middleware support to wrap jobs on the event loop, enabling middleware to run in the event loop context for both sync and async tasks.

* **Documentation**
  * Reorganized and clarified middleware concepts, distinguishing between task middleware and worker middleware with improved explanations of execution contexts and ordering.
  * Updated API reference to include the new worker middleware type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->