### PR TITLE
Keep heartbeat alive during graceful shutdown

### DIFF
--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -549,11 +549,18 @@ class Worker:
             extra=self._log_extra(action="abort_job", context=context, job_result=None),
         )
 
-    async def _shutdown(self, side_tasks: list[asyncio.Task[Any]]):
+    async def _shutdown(
+        self,
+        heartbeat_task: asyncio.Task[Any],
+        side_tasks: list[asyncio.Task[Any]],
+    ):
         """
         Gracefully shutdown the worker by cancelling side tasks
         and waiting for all pending jobs.
         """
+        # The heartbeat is deliberately kept running while we drain in-flight
+        # jobs below: the worker is still alive and processing them, and a
+        # frozen heartbeat would let stalled-worker recovery reclaim those jobs.
         await utils.cancel_and_capture_errors(side_tasks)
 
         now = time.time()
@@ -586,6 +593,9 @@ class Worker:
             )
             await self._abort_running_jobs()
 
+        # Jobs have drained: stop the heartbeat before unregistering the worker.
+        await utils.cancel_and_capture_errors([heartbeat_task])
+
         assert self.worker_id is not None
         await self.app.job_manager.unregister_worker(self.worker_id)
         logger.debug(f"Unregistered finished worker {self.worker_id} from the database")
@@ -604,10 +614,18 @@ class Worker:
 
         await asyncio.gather(*self._running_jobs, return_exceptions=True)
 
-    def _start_side_tasks(self) -> list[asyncio.Task[Any]]:
-        """Start side tasks such as periodic deferrer and notification listener"""
+    def _start_side_tasks(
+        self,
+    ) -> tuple[asyncio.Task[Any], list[asyncio.Task[Any]]]:
+        """Start side tasks such as periodic deferrer and notification listener.
+
+        The heartbeat is returned separately because it must outlive the other
+        side tasks during shutdown (see _shutdown).
+        """
+        heartbeat_task = asyncio.create_task(
+            self._update_heartbeat(), name="update_heartbeats"
+        )
         side_tasks = [
-            asyncio.create_task(self._update_heartbeat(), name="update_heartbeats"),
             asyncio.create_task(self._periodic_deferrer(), name="deferrer"),
             asyncio.create_task(self._poll_jobs_to_abort(), name="poll_jobs_to_abort"),
         ]
@@ -617,7 +635,7 @@ class Worker:
                 queues=self.queues,
             )
             side_tasks.append(asyncio.create_task(listener_coro, name="listener"))
-        return side_tasks
+        return heartbeat_task, side_tasks
 
     async def _monitor_side_tasks(self, side_tasks: list[asyncio.Task[Any]]):
         """Monitor side tasks and stop the worker if any task fails"""
@@ -665,9 +683,10 @@ class Worker:
         self._new_job_event.clear()
         self._running_jobs = {}
         self._job_semaphore = asyncio.Semaphore(self.concurrency)
-        side_tasks = self._start_side_tasks()
+        heartbeat_task, side_tasks = self._start_side_tasks()
         side_tasks_monitor = asyncio.create_task(
-            self._monitor_side_tasks(side_tasks), name="side_tasks_monitor"
+            self._monitor_side_tasks([heartbeat_task, *side_tasks]),
+            name="side_tasks_monitor",
         )
 
         context = (
@@ -702,4 +721,4 @@ class Worker:
         finally:
             if not side_tasks_monitor.done():
                 side_tasks_monitor.cancel()
-            await self._shutdown(side_tasks=side_tasks)
+            await self._shutdown(heartbeat_task=heartbeat_task, side_tasks=side_tasks)

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -831,6 +831,50 @@ async def test_worker_id_and_heartbeat_lifecycle(app: App):
     assert connector.workers == {}
 
 
+async def test_heartbeat_continues_during_graceful_shutdown(app: App):
+    """
+    A draining worker must keep updating its heartbeat while it waits for its
+    in-flight jobs to finish. Otherwise it looks dead to stalled-worker
+    recovery, which would reclaim jobs that are still being processed.
+    """
+    connector = cast(InMemoryConnector, app.connector)
+
+    @app.task(queue="some_queue")
+    async def long_job():
+        await asyncio.sleep(0.3)
+
+    await long_job.defer_async()
+
+    worker = Worker(
+        app,
+        update_heartbeat_interval=0.05,
+        shutdown_graceful_timeout=1.0,
+    )
+    run_task = await start_worker(worker)
+
+    worker_id = worker.worker_id
+    assert worker_id is not None
+
+    # Let the job start being processed.
+    await asyncio.sleep(0.05)
+
+    # Begin a graceful shutdown while the job is still running.
+    worker.stop()
+    heartbeat_at_shutdown = connector.workers[worker_id]
+
+    # While the worker drains its in-flight job, the heartbeat must keep
+    # advancing instead of freezing the moment shutdown begins.
+    await asyncio.sleep(0.15)
+    assert worker_id in connector.workers
+    assert connector.workers[worker_id] > heartbeat_at_shutdown
+
+    await run_task
+
+    # Once the job has drained and shutdown completes, the worker is gone.
+    assert worker.worker_id is None
+    assert connector.workers == {}
+
+
 async def test_job_receives_worker_id(app: App):
     @app.task(queue="some_queue")
     async def t():


### PR DESCRIPTION
A draining worker is still alive and processing its in-flight jobs, but _shutdown cancelled every side task (including the heartbeat) before waiting for those jobs to drain. The frozen heartbeat made the worker look dead to stalled-worker recovery, which could then reclaim jobs that were still being processed.

Cancel the other side tasks immediately (a draining worker must not fetch new jobs, defer periodics or listen for notifications), but keep the heartbeat beating until in-flight jobs have drained or been aborted, and only then cancel it before unregistering the worker.

This is kind of fixable on library's users side with something like this but it looks like it would be worth it to address this in the library itself.

```python
HEARTBEAT_SIDE_TASK_NAME = "update_heartbeats"

class DrainHeartbeatWorker(Worker):
    """Worker that keeps beating while it gracefully drains in-flight jobs."""

    async def _shutdown(self, side_tasks: list) -> None:
        heartbeat_tasks = [
            t for t in side_tasks if t.get_name() == HEARTBEAT_SIDE_TASK_NAME
        ]
        other_tasks = [
            t for t in side_tasks if t.get_name() != HEARTBEAT_SIDE_TASK_NAME
        ]

        await utils.cancel_and_capture_errors(other_tasks)
        try:
            await super()._shutdown(side_tasks=[])
        finally:
            await utils.cancel_and_capture_errors(heartbeat_tasks)
```


<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker graceful shutdown sequence to maintain heartbeat signals while draining in-flight jobs, ensuring proper coordination and reliability before full unregistration.

* **Tests**
  * Added test coverage validating heartbeat behavior during graceful shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->