### PR TITLE
Make queueing_lock detail parsing locale-agnostic (fixes #1531)

### DIFF
--- a/procrastinate/sync_psycopg_connector.py
+++ b/procrastinate/sync_psycopg_connector.py
@@ -16,6 +16,32 @@ from procrastinate import connector, exceptions, manager
 
 logger = logging.getLogger(__name__)
 
+# The structure ``(columns)=(values)`` in the error detail is not translated by
+# PostgreSQL, but the surrounding text (e.g. the "Key " prefix) is, depending on
+# the server's ``lc_messages`` setting. We therefore only rely on the
+# locale-agnostic ``(columns)=(values)`` part to extract the queueing lock.
+QUEUEING_LOCK_DETAIL_RE = re.compile(r"\((.*?)\)=\((.*?)\)")
+
+
+def _extract_queueing_lock(message_detail: str | None) -> str | None:
+    """
+    Extract the queueing lock value from a UniqueViolation error detail.
+
+    Returns ``None`` if the value cannot be extracted, e.g. because the error
+    detail is missing or has an unexpected format. This is best-effort: the value
+    is only used to build a human-readable error message, so failing to extract
+    it must not prevent the ``AlreadyEnqueued`` error from being raised.
+    """
+    if not message_detail:
+        return None
+    match = QUEUEING_LOCK_DETAIL_RE.search(message_detail)
+    if match is None:
+        return None
+    column, value = match.groups()
+    if column != "queueing_lock":
+        return None
+    return value
+
 
 @contextlib.contextmanager
 def wrap_exceptions() -> Generator[None, None, None]:
@@ -31,11 +57,7 @@ def wrap_exceptions() -> Generator[None, None, None]:
         constraint_name = exc.diag.constraint_name
         queueing_lock = None
         if constraint_name == manager.QUEUEING_LOCK_CONSTRAINT:
-            assert exc.diag.message_detail
-            match = re.search(r"Key \((.*?)\)=\((.*?)\)", exc.diag.message_detail)
-            assert match
-            column, queueing_lock = match.groups()
-            assert column == "queueing_lock"
+            queueing_lock = _extract_queueing_lock(exc.diag.message_detail)
 
         raise exceptions.UniqueViolation(
             constraint_name=constraint_name, queueing_lock=queueing_lock

--- a/tests/unit/test_sync_psycopg_connector.py
+++ b/tests/unit/test_sync_psycopg_connector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import psycopg
 import pytest
 
-from procrastinate import exceptions, sync_psycopg_connector
+from procrastinate import exceptions, manager, sync_psycopg_connector
 
 
 def test_wrap_exceptions_wraps():
@@ -13,6 +13,67 @@ def test_wrap_exceptions_wraps():
 
     with pytest.raises(exceptions.ConnectorException):
         func()
+
+
+class _FakeUniqueViolation(psycopg.errors.UniqueViolation):
+    # ``diag`` is a read-only property on the real exception, backed by a libpq
+    # result that we can't easily fabricate offline, so we override it here.
+    def __init__(self, constraint_name, message_detail):
+        super().__init__("duplicate key value violates ...")
+        self._fake_diag = type(
+            "FakeDiag",
+            (),
+            {"constraint_name": constraint_name, "message_detail": message_detail},
+        )()
+
+    @property
+    def diag(self):
+        return self._fake_diag
+
+
+def _make_unique_violation(constraint_name, message_detail):
+    return _FakeUniqueViolation(constraint_name, message_detail)
+
+
+@pytest.mark.parametrize(
+    "message_detail",
+    [
+        # English (default lc_messages)
+        pytest.param("Key (queueing_lock)=(some_lock) already exists.", id="english"),
+        # Russian (lc_messages=ru_RU.UTF-8): the "Key" prefix is translated but
+        # the "(columns)=(values)" structure is not. See issue #1531.
+        pytest.param(
+            'Ключ "(queueing_lock)=(some_lock)" уже существует.', id="russian"
+        ),
+    ],
+)
+def test_wrap_exceptions_queueing_lock_locale_agnostic(message_detail):
+    @sync_psycopg_connector.wrap_exceptions()
+    def func():
+        raise _make_unique_violation(manager.QUEUEING_LOCK_CONSTRAINT, message_detail)
+
+    with pytest.raises(exceptions.UniqueViolation) as excinfo:
+        func()
+
+    assert excinfo.value.constraint_name == manager.QUEUEING_LOCK_CONSTRAINT
+    assert excinfo.value.queueing_lock == "some_lock"
+
+
+def test_wrap_exceptions_queueing_lock_unparseable_detail():
+    # Even if the queueing lock cannot be extracted from the (possibly
+    # translated) error detail, a UniqueViolation must still be raised instead
+    # of a bare AssertionError (issue #1531).
+    @sync_psycopg_connector.wrap_exceptions()
+    def func():
+        raise _make_unique_violation(
+            manager.QUEUEING_LOCK_CONSTRAINT, "unexpected detail format"
+        )
+
+    with pytest.raises(exceptions.UniqueViolation) as excinfo:
+        func()
+
+    assert excinfo.value.constraint_name == manager.QUEUEING_LOCK_CONSTRAINT
+    assert excinfo.value.queueing_lock is None
 
 
 def test_wrap_exceptions_success():


### PR DESCRIPTION
Closes #1531

### Summary

When PostgreSQL uses a non-English `lc_messages` (e.g. `ru_RU.UTF-8`), a `queueing_lock` conflict crashes with a bare `AssertionError` inside `sync_psycopg_connector.wrap_exceptions()` instead of raising `procrastinate.exceptions.AlreadyEnqueued`.

The cause is in the `UniqueViolation` handler:

```python
match = re.search(r"Key \((.*?)\)=\((.*?)\)", exc.diag.message_detail)
assert match
```

The regex assumes the error detail is English. With a translated locale, the `message_detail` text is localized (e.g. the `Key ` prefix becomes `Ключ `), so the regex matches nothing, `match` is `None`, and `assert match` raises `AssertionError`. On installations with a localized `lc_messages`, a normal duplicate-enqueue flow becomes an internal library error.

Since `psycopg_connector.wrap_exceptions()` reuses this same context manager, both the async and sync psycopg connectors are affected, and this single fix covers both.

### Fix

- Match only on the locale-agnostic `(columns)=(values)` structure, which PostgreSQL does **not** translate, instead of the translated `Key ` prefix.
- Extract the queueing lock in a small `_extract_queueing_lock()` helper that falls back to `None` (best-effort) instead of asserting. The extracted value is only used to build a human-readable error message, so failing to parse it must never prevent `UniqueViolation` / `AlreadyEnqueued` from being raised.

### Tests

Added unit tests in `tests/unit/test_sync_psycopg_connector.py`:

- `test_wrap_exceptions_queueing_lock_locale_agnostic` — parametrized over an English detail and a Russian (`ru_RU.UTF-8`) detail; both now correctly raise `UniqueViolation` with `queueing_lock == "some_lock"`. The `russian` case fails with `AssertionError` on the pristine code and passes with the fix.
- `test_wrap_exceptions_queueing_lock_unparseable_detail` — an unparseable detail still raises `UniqueViolation` (with `queueing_lock=None`) rather than `AssertionError`.

Verified the new tests fail on the unpatched code and pass after the fix. The full unit suite (547 tests) passes, and `ruff check`, `ruff format`, and `basedpyright` are clean on the changed files. The database-backed integration tests were not run locally (no PostgreSQL instance available), but the locale bug and fix are fully exercised by the deterministic unit tests above.

Note: the same fragile parsing exists in the psycopg2, aiopg, and SQLAlchemy contrib connectors; I kept this PR scoped to the psycopg connector from the issue and am happy to apply the same fix to the others if you'd prefer.

Disclosure: prepared with AI assistance; reviewed and verified locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PostgreSQL unique-violation errors so lock information is extracted more reliably across different locale message formats.
  * Gracefully handles unexpected error details by leaving lock information unset instead of failing parsing.

* **Tests**
  * Added coverage for locale-agnostic parsing of unique-violation details.
  * Added a test to verify behavior when error details can’t be parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->