### PR TITLE
Don't hang forever when cancelling a worker whose database connection is unresponsive

### DIFF
--- a/docs/howto/advanced/shutdown.md
+++ b/docs/howto/advanced/shutdown.md
@@ -10,6 +10,15 @@ If a `shutdown_graceful_timeout` option is specified, the worker will attempt to
 
 The worker will then wait for all jobs to complete.
 
+There is one situation in which the worker cannot observe the stop request at all: a database
+call that never returns, for example on a connection left half-open by a database failover or a
+proxy. By default, cancelling the worker then waits forever. If a `shutdown_timeout` option is
+specified, the worker waits up to that long for its run loop to stop after `run_worker_async` is
+cancelled, then cancels the run loop, and — if even the cancellation has no effect on the stuck
+database call — abandons it, so that cancelling the worker always terminates. As the run loop
+waits for running jobs before exiting, `shutdown_timeout` should be greater than
+`shutdown_graceful_timeout`.
+
 
 :::{note}
 The worker aborts its remaining jobs by:
@@ -69,6 +78,24 @@ async with app.open_async():
     except asyncio.CancelledError:
         # at this point, the worker is shutdown.
         # Any job that took longer than 10 seconds to complete have aborted
+        pass
+```
+
+### Ensure a cancelled worker terminates even if its database connection is dead
+
+```python
+async with app.open_async():
+    worker = asyncio.create_task(
+        app.run_worker_async(shutdown_graceful_timeout=10, shutdown_timeout=30)
+    )
+    # eventually
+    worker.cancel()
+    try:
+        await worker
+    except asyncio.CancelledError:
+        # This await is bounded: if the run loop cannot observe the stop
+        # request (e.g. the database connection is unresponsive), it is
+        # cancelled and, at worst, abandoned, instead of hanging forever.
         pass
 ```
 

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -38,6 +38,7 @@ class WorkerOptions(TypedDict):
     fetch_job_polling_interval: NotRequired[float]
     abort_job_polling_interval: NotRequired[float]
     shutdown_graceful_timeout: NotRequired[float]
+    shutdown_timeout: NotRequired[float]
     listen_notify: NotRequired[bool]
     delete_jobs: NotRequired[str | jobs.DeleteJobCondition]
     additional_context: NotRequired[dict[str, Any]]
@@ -304,6 +305,25 @@ class App(blueprints.Blueprint):
             Indicates the maximum duration (in seconds) the worker waits for jobs to
             complete when requested to stop. Jobs that have not been completed by that time
             are aborted. A value of None corresponds to no timeout.
+
+            (defaults to None)
+        shutdown_timeout: ``float``
+            Indicates the maximum duration (in seconds) the worker waits for its
+            run loop to stop after ``run_worker_async()`` is cancelled, before
+            cancelling the run loop; then again before abandoning it. Cancelling
+            the worker therefore takes at most twice this value.
+
+            The run loop stops as soon as it is asked to, unless it is blocked on
+            a database call that never returns (e.g. on a connection left
+            half-open by a database failover), in which case it never observes
+            the request. This timeout ensures that cancelling the worker always
+            terminates.
+
+            As the run loop waits for running jobs to complete before it exits,
+            this should be greater than ``shutdown_graceful_timeout``.
+
+            A value of None corresponds to no timeout, meaning that a worker
+            whose connection is unresponsive may never shut down.
 
             (defaults to None)
         listen_notify : ``bool``

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -41,6 +41,7 @@ class Worker:
         fetch_job_polling_interval: float = FETCH_JOB_POLLING_INTERVAL,
         abort_job_polling_interval: float = ABORT_JOB_POLLING_INTERVAL,
         shutdown_graceful_timeout: float | None = None,
+        shutdown_timeout: float | None = None,
         listen_notify: bool = True,
         delete_jobs: str | jobs.DeleteJobCondition | None = None,
         additional_context: dict[str, Any] | None = None,
@@ -97,6 +98,7 @@ class Worker:
         self._job_semaphore = asyncio.Semaphore(self.concurrency)
         self._stop_event = asyncio.Event()
         self.shutdown_graceful_timeout = shutdown_graceful_timeout
+        self.shutdown_timeout = shutdown_timeout
         self._job_ids_to_abort: dict[int, job_context.AbortReason] = dict()
         self.run_task: asyncio.Task[Any] | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -465,7 +467,44 @@ class Worker:
         except asyncio.CancelledError:
             # worker.run is cancelled, usually by cancelling app.run_worker_async
             self.stop()
-            await loop_task
+            # The loop task may be blocked on a database call that cannot observe
+            # the stop event (e.g. a connection left half-open by a database
+            # failover). Waiting for it unconditionally would hang the shutdown
+            # forever. Without shutdown_timeout, this waits forever, as before;
+            # hence a pending loop task implies a shutdown_timeout was set.
+            _, pending = await asyncio.wait({loop_task}, timeout=self.shutdown_timeout)
+            if not pending:
+                # Surface an error from the loop rather than the cancellation,
+                # as awaiting the loop task directly used to do.
+                await loop_task
+            else:
+                self.logger.warning(
+                    "Worker loop did not stop within shutdown_timeout. Cancelling it",
+                    extra=self._log_extra(
+                        context=None,
+                        action="shutdown_loop_timeout",
+                        queues=self.queues,
+                        job_result=None,
+                    ),
+                )
+                loop_task.cancel()
+                # The cancellation itself may be swallowed by a driver blocked on
+                # an unresponsive connection, so this wait is bounded too. If the
+                # loop task is still pending afterwards, it is abandoned: the
+                # caller has asked us to stop and must not be blocked further.
+                _, pending = await asyncio.wait(
+                    {loop_task}, timeout=self.shutdown_timeout
+                )
+                if pending:
+                    self.logger.warning(
+                        "Worker loop did not react to cancellation. Abandoning it",
+                        extra=self._log_extra(
+                            context=None,
+                            action="shutdown_loop_abandoned",
+                            queues=self.queues,
+                            job_result=None,
+                        ),
+                    )
             raise
         finally:
             # The loop is about to go away; a late stop() (e.g. from another
@@ -587,8 +626,44 @@ class Worker:
             await self._abort_running_jobs()
 
         assert self.worker_id is not None
-        await self.app.job_manager.unregister_worker(self.worker_id)
-        logger.debug(f"Unregistered finished worker {self.worker_id} from the database")
+        # Unregistering is best effort: a worker that could not unregister (for
+        # instance because its database connection is unresponsive) is
+        # eventually pruned through its stale heartbeat by another worker.
+        # Bound it like the run loop itself, so that a shutdown with a stuck
+        # connection can complete (without shutdown_timeout, wait forever, as
+        # before).
+        unregister_task = asyncio.create_task(
+            self.app.job_manager.unregister_worker(self.worker_id)
+        )
+        _, pending = await asyncio.wait(
+            {unregister_task}, timeout=self.shutdown_timeout
+        )
+        if not pending:
+            # Surface an error from the task, as awaiting it directly used to do.
+            await unregister_task
+            logger.debug(
+                f"Unregistered finished worker {self.worker_id} from the database"
+            )
+        else:
+            self.logger.warning(
+                "Could not unregister the worker within shutdown_timeout. "
+                "Its heartbeat will go stale and it will eventually be pruned",
+                extra=self._log_extra(
+                    context=None,
+                    action="shutdown_unregister_timeout",
+                    queues=self.queues,
+                    job_result=None,
+                ),
+            )
+            unregister_task.cancel()
+
+            def _consume_result(task: asyncio.Task[Any]) -> None:
+                # Consume a late failure so it isn't logged as a never-retrieved
+                # task exception.
+                if not task.cancelled() and task.exception():
+                    logger.debug(f"Late unregister failure: {task.exception()!r}")
+
+            unregister_task.add_done_callback(_consume_result)
         self.worker_id = None
 
         self.logger.info(

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -30,6 +30,15 @@ FETCH_JOB_POLLING_INTERVAL = 5.0  # seconds
 ABORT_JOB_POLLING_INTERVAL = 5.0  # seconds
 
 
+def _consume_task_exception(task: asyncio.Task[Any]) -> None:
+    # Consume the outcome of a task completing after it was given up on, so
+    # that a late failure isn't logged as a never-retrieved task exception.
+    if not task.cancelled() and task.exception():
+        logger.debug(
+            f"{task.get_name()} failed after being given up on: {task.exception()!r}"
+        )
+
+
 class Worker:
     def __init__(
         self,
@@ -99,6 +108,18 @@ class Worker:
         self._stop_event = asyncio.Event()
         self.shutdown_graceful_timeout = shutdown_graceful_timeout
         self.shutdown_timeout = shutdown_timeout
+        if (
+            shutdown_timeout is not None
+            and shutdown_graceful_timeout is not None
+            and shutdown_timeout <= shutdown_graceful_timeout
+        ):
+            self.logger.warning(
+                "shutdown_timeout should be greater than shutdown_graceful_timeout: "
+                "the run loop waits up to shutdown_graceful_timeout for running "
+                "jobs when stopping, so a smaller shutdown_timeout cancels it "
+                "while it may still be draining them",
+                extra={"action": "shutdown_timeout_misconfigured"},
+            )
         self._job_ids_to_abort: dict[int, job_context.AbortReason] = dict()
         self.run_task: asyncio.Task[Any] | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -505,6 +526,7 @@ class Worker:
                             job_result=None,
                         ),
                     )
+                loop_task.add_done_callback(_consume_task_exception)
             raise
         finally:
             # The loop is about to go away; a late stop() (e.g. from another
@@ -633,7 +655,8 @@ class Worker:
         # connection can complete (without shutdown_timeout, wait forever, as
         # before).
         unregister_task = asyncio.create_task(
-            self.app.job_manager.unregister_worker(self.worker_id)
+            self.app.job_manager.unregister_worker(self.worker_id),
+            name="unregister_worker",
         )
         _, pending = await asyncio.wait(
             {unregister_task}, timeout=self.shutdown_timeout
@@ -656,14 +679,7 @@ class Worker:
                 ),
             )
             unregister_task.cancel()
-
-            def _consume_result(task: asyncio.Task[Any]) -> None:
-                # Consume a late failure so it isn't logged as a never-retrieved
-                # task exception.
-                if not task.cancelled() and task.exception():
-                    logger.debug(f"Late unregister failure: {task.exception()!r}")
-
-            unregister_task.add_done_callback(_consume_result)
+            unregister_task.add_done_callback(_consume_task_exception)
         self.worker_id = None
 
         self.logger.info(

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -84,6 +84,65 @@ async def test_worker_run_wait_stop(app: App, caplog):
     }
 
 
+async def test_cancelling_run_does_not_hang_on_stuck_loop_task(app: App, caplog):
+    # https://github.com/procrastinate-org/procrastinate/issues/1513
+    # The loop task is shielded, so it only stops by observing the stop event.
+    # A database call that never returns never observes it, and waiting for the
+    # loop task would then hang the shutdown forever.
+    caplog.set_level("WARNING")
+    worker = Worker(app, wait=True, install_signal_handlers=False, shutdown_timeout=0.1)
+    fetching = asyncio.Event()
+
+    async def stuck_fetch_job(**kwargs):
+        fetching.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            # Model an unresponsive connection: psycopg does not honour the
+            # first cancellation, because it waits for the server to
+            # acknowledge the query cancellation before re-raising. A directly
+            # cancellable sleep would pass even without the fix.
+            await asyncio.sleep(1)
+            raise
+
+    app.job_manager.fetch_job = stuck_fetch_job
+    run_task = asyncio.create_task(worker.run())
+    await asyncio.wait_for(fetching.wait(), timeout=1)
+
+    run_task.cancel()
+
+    # asyncio.wait, not wait_for: wait_for cancels only once and would itself
+    # hang on the swallowed cancellation instead of failing the test.
+    done, _ = await asyncio.wait({run_task}, timeout=2)
+
+    assert done, "run() never returned after being cancelled"
+    with pytest.raises(asyncio.CancelledError):
+        run_task.result()
+    assert "Worker loop did not react to cancellation" in caplog.text
+
+
+async def test_stopping_worker_does_not_hang_on_stuck_unregister(app: App, caplog):
+    # Shutdown makes its own database calls (unregister_worker); if the
+    # connection is unresponsive by then, they must not hang the shutdown.
+    caplog.set_level("WARNING")
+    worker = Worker(app, wait=True, install_signal_handlers=False, shutdown_timeout=0.1)
+
+    async def stuck_unregister(worker_id):
+        await asyncio.Event().wait()
+
+    app.job_manager.unregister_worker = stuck_unregister
+    run_task = asyncio.create_task(worker.run())
+    await asyncio.sleep(0.01)
+
+    worker.stop()
+
+    done, _ = await asyncio.wait({run_task}, timeout=2)
+
+    assert done, "run() never returned after stop() with a stuck unregister"
+    await run_task  # a plain stop is not an error
+    assert "Could not unregister the worker" in caplog.text
+
+
 async def test_stop_requested_before_run_loop_starts_is_not_lost(app: App):
     worker = Worker(app, wait=True, install_signal_handlers=False)
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -143,6 +143,17 @@ async def test_stopping_worker_does_not_hang_on_stuck_unregister(app: App, caplo
     assert "Could not unregister the worker" in caplog.text
 
 
+def test_shutdown_timeout_not_greater_than_graceful_timeout_warns(app: App, caplog):
+    caplog.set_level("WARNING")
+
+    Worker(app, shutdown_graceful_timeout=10, shutdown_timeout=5)
+
+    assert (
+        "shutdown_timeout should be greater than shutdown_graceful_timeout"
+        in caplog.text
+    )
+
+
 async def test_stop_requested_before_run_loop_starts_is_not_lost(app: App):
     worker = Worker(app, wait=True, install_signal_handlers=False)
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -98,7 +98,7 @@ async def test_cancelling_run_does_not_hang_on_stuck_loop_task(app: App, caplog)
         try:
             await asyncio.Event().wait()
         except asyncio.CancelledError:
-            # Model an unresponsive connection: psycopg does not honour the
+            # Model an unresponsive connection: psycopg does not honor the
             # first cancellation, because it waits for the server to
             # acknowledge the query cancellation before re-raising. A directly
             # cancellable sleep would pass even without the fix.


### PR DESCRIPTION
Closes #1513

## The problem

If a worker's database connection stops responding (a half-open connection: the server side was reset by a failover or proxy, but the client socket stays open), the worker can never be stopped. A signal, `worker.stop()`, or cancelling `run_worker_async()` all wait forever; the only way out is to kill the process. TCP keepalives and `tcp_user_timeout` don't catch it when a middlebox keeps answering the probes.

We hit this in production: after a connection event on a managed PostgreSQL (Postgres itself never restarted), a worker silently stopped fetching jobs for 7 hours, logging nothing, while the rest of the process kept working, and it could only be recovered by restarting the process.

## Why it hangs

`Worker.run()` shields the run loop and relies on the stop event for a graceful shutdown. `stop()` only sets `_stop_event`, which the run loop checks *between* fetches, so a fetch that never returns never observes it. And because the loop task is shielded, nothing ever cancels it: `run()` waits forever for a task that cannot finish.

## The change

Adds an opt-in `shutdown_timeout` option (default `None`: behavior is unchanged).

- After **any** stop request (signal, `worker.stop()`, `wait=False`, or cancelling `run_worker_async()`), the worker waits up to `shutdown_timeout` for its run loop to **start shutting down**. If it hasn't, the run loop is stuck on the database: the worker logs a warning and cancels it, waits up to `shutdown_timeout` again, and if the cancellation has no effect either, abandons it with a second warning.
- After such a forced stop, the worker **does not try to unregister** from the database it just found unresponsive. It is pruned later through its stale heartbeat (`prune_stalled_workers`). In a normal shutdown, unregistering is still attempted, bounded by `shutdown_timeout`.
- `shutdown_timeout` **does not bound waiting for running jobs**. Once the run loop has reached `_shutdown()` it is not stuck, and draining jobs remains governed by `shutdown_graceful_timeout`, exactly as today. (An earlier version of this PR bounded the whole shutdown, which could cancel long-running jobs and leave them in `doing`; the tests below cover that.)
- On a signal/`stop()`, a forced stop still returns normally from `run()`; on cancellation, `CancelledError` is propagated as before.

## Relationship to the psycopg fixes

The cancellation that the abandon path guards against was a psycopg bug, which I reported as psycopg/psycopg#1371. It is now fixed upstream by psycopg/psycopg#1411 (core: a cancelled query on an unresponsive server gives up after ~5s; requires libpq >= 17) and psycopg/psycopg#1412 (pool: the connection check no longer replaces `CancelledError`), both merged for psycopg 3.3.6 / psycopg_pool 3.3.2.

Those fixes do not fix this issue on their own: with psycopg master and no `shutdown_timeout`, stopping a worker stuck on a half-open connection still hangs, because nothing cancels the shielded run loop. `shutdown_timeout` is what delivers that cancellation. With fixed psycopg the loop then actually finishes shortly after being cancelled; the abandon path remains for older psycopg or libpq.

## End-to-end results

Against a real half-open connection (an in-process TCP proxy that strands established connections while new ones keep working), Python 3.13, libpq 17, `shutdown_timeout=8`, stopping the worker with a single SIGTERM through the sync `app.run_worker()`:

| Scenario | Before | After |
|---|---|---|
| All connections stranded, psycopg master | hangs until killed | cancelled at 8s, loop finishes at ~14s, process exits (rc 0) |
| All connections stranded, psycopg 3.3.5 | hangs until killed | cancelled at 8s, abandoned at 16s, process exits at ~17s |
| Same, `shutdown_timeout` unset | hangs until killed | hangs until killed (unchanged) |
| Healthy database, 12s job running | job succeeds, clean stop | job succeeds, clean stop, no warning |
| Healthy database, 12s job, `shutdown_graceful_timeout=3` | job aborted at 3s (existing behavior) | job aborted at 3s, no warning |

Cancelling `run_worker_async()` (inside `async with app.open_async()`) and the `procrastinate worker` CLI (with `shutdown_timeout` in `worker_defaults`) behave the same as the first row.

## Known limitations

- **An outage that starts while the worker is already draining jobs is not covered.** A job whose final status write hangs keeps the worker from stopping, with or without `shutdown_graceful_timeout`. This is the same as on `main`; bounding it would mean bounding job completion writes, which I left out of this PR.
- **Abandoning cannot guarantee that the process exits.** `asyncio.run()` cancels and awaits remaining tasks when it closes, so a task that ignores every cancellation would still block exit. In every stack I tested (psycopg 3.3.5 and master), that final cancellation was honored and the process exited.
- **It does not make a worker recover from a wedged connection without a stop request.** The fetch loop still stalls until something stops the worker.

## Tests

Unit tests model a database call that ignores its first cancellation (a plainly cancellable `sleep` would pass without the fix), and bound the tests with `asyncio.wait` rather than `wait_for`, which cancels only once and would itself hang:

- stuck run loop on cancellation, on `stop()`, and on cancellation during an ongoing stop (not restarting the budget)
- a forced stop skips unregistering; a stuck unregister in a normal shutdown is bounded, including when the loop fails on its own
- `shutdown_timeout` does not bound waiting for jobs (stop, cancel, stop then cancel, `wait=False`), and `shutdown_graceful_timeout` still aborts jobs
- a loop that stops in time still surfaces its error

Each new regression test was checked to fail without the change it covers. The existing unit, integration (`test_wait_stop.py`, worker tests) and stop/signal acceptance tests pass.

---

*Disclosure: this change was written with the assistance of an LLM (Claude). The bug was reproduced and the fix verified end-to-end against a real half-open connection; the evidence is above.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDZXs9urabEVuzyeuZ4rTR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `shutdown_timeout` setting to bound worker shutdown when cancellation, run-loop startup, or cleanup becomes unresponsive.
  * Running jobs continue to follow `shutdown_graceful_timeout`, while forced shutdowns avoid waiting indefinitely for worker unregistration.
* **Bug Fixes**
  * Prevented worker shutdown from hanging on unresponsive database calls or cleanup operations.
* **Documentation**
  * Expanded shutdown guidance with timeout behavior, stuck run-loop details, driver timeout recommendations, and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->