### PR TITLE
Keep monitoring side tasks after one returns cleanly

### DIFF
--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -622,24 +622,28 @@ class Worker:
     async def _monitor_side_tasks(self, side_tasks: list[asyncio.Task[Any]]):
         """Monitor side tasks and stop the worker if any task fails"""
         try:
-            done, _pending = await asyncio.wait(
-                side_tasks, return_when=asyncio.FIRST_COMPLETED
-            )
-            for task in done:
-                if exc := task.exception():
-                    self.logger.error(
-                        f"Side task {task.get_name()} failed with exception: {exc}, stopping worker",
-                        extra=self._log_extra(
-                            action="side_task_failed",
-                            context=None,
-                            job_result=None,
-                            task_name=task.get_name(),
-                            exception=str(exc),
-                        ),
-                        exc_info=exc,
-                    )
-                    self.stop()
-                    return
+            pending = set(side_tasks)
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in done:
+                    if task.cancelled():
+                        continue
+                    if exc := task.exception():
+                        self.logger.error(
+                            f"Side task {task.get_name()} failed with exception: {exc}, stopping worker",
+                            extra=self._log_extra(
+                                action="side_task_failed",
+                                context=None,
+                                job_result=None,
+                                task_name=task.get_name(),
+                                exception=str(exc),
+                            ),
+                            exc_info=exc,
+                        )
+                        self.stop()
+                        return
         except Exception as exc:
             self.logger.exception(
                 f"Side task monitor failed: {exc}",

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -905,3 +905,26 @@ async def test_worker_stops_when_side_task_fails(
     assert "Simulated heartbeat failure" in error_record.message
     assert "stopping worker" in error_record.message
     assert error_record.task_name == "update_heartbeats"
+
+
+async def test_worker_stops_when_side_task_fails_after_another_returned(app: App):
+    async def fail_later():
+        await asyncio.sleep(0.01)
+        raise ValueError("Simulated side task failure")
+
+    worker = Worker(app, install_signal_handlers=False)
+
+    # The periodic deferrer returns immediately when no periodic task is
+    # registered, which must not end supervision of the other side tasks.
+    returns_immediately = asyncio.create_task(asyncio.sleep(0), name="deferrer_like")
+    fails_later = asyncio.create_task(fail_later(), name="fails_later")
+
+    monitor = asyncio.create_task(
+        worker._monitor_side_tasks([returns_immediately, fails_later])
+    )
+    await asyncio.sleep(0.05)
+
+    assert fails_later.done()
+    assert worker._stop_event.is_set()
+
+    monitor.cancel()


### PR DESCRIPTION
Closes #1597

`_monitor_side_tasks` awaited `asyncio.wait(..., FIRST_COMPLETED)` once and only acted when a completed task had raised, so a side task that returned *cleanly* silently ended supervision of all the others. That is the normal path rather than an edge case: `PeriodicDeferrer.worker()` returns immediately when no periodic task is registered, so any app without periodic tasks loses side-task supervision at startup and a later listener/heartbeat failure no longer stops the worker. The monitor now loops over the remaining pending tasks until one fails or all have finished.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.

### Successful PR Checklist:
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s):
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background task monitoring so all pending tasks are processed, including tasks that finish at different times.
  * Cancelled tasks no longer interrupt monitoring.
  * Failures continue to trigger worker shutdown and provide error details.

* **Tests**
  * Added regression coverage for failures occurring after an earlier task completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->