### PR TITLE
Restore the coverage comment's token permissions

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -6,14 +6,17 @@ on: # zizmor: ignore[dangerous-triggers]
     types:
       - completed
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
     name: Run tests & display coverage
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write # Post the comment, and edit it on later runs
+      actions: read # Download the comment artifact from the triggering CI run
+      contents: read
     steps:
       # DO NOT run actions/checkout@v2 here, for securitity reasons
       # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/


### PR DESCRIPTION
#1607 added a workflow-level `permissions: contents: read` to `coverage-comment.yml`. Declaring any block scopes every omitted permission to none, so the job lost `pull-requests: write` and `actions: read` and can no longer download the comment artifact or post/update the comment. Being a `workflow_run` workflow, it never ran during that PR's checks, so nothing caught it.

Restores the permissions documented in the action's own README: `permissions: {}` at workflow level, granted per-job.

### Successful PR Checklist:

- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s):
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [x] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
