### PR TITLE
Pin CI to the committed lockfile

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,6 +1,9 @@
 name: autofix.ci
 on: [pull_request]
 
+env:
+  UV_FROZEN: "true"
+
 permissions:
   contents: read
 


### PR DESCRIPTION
CI runs `uv run` / `uv sync` with no guard today, so when `pyproject.toml` and `uv.lock` disagree, uv quietly re-resolves, rewrites `uv.lock` inside the runner and tests a dependency set that was never committed. The job goes green, the rewritten lock is thrown away, and the same commit can resolve differently on a later rerun.

`UV_FROZEN: "true"` on every uv-using workflow makes CI use the committed lock and nothing else.

On its own that would hide the drift rather than fix it — under `UV_FROZEN`, `uv lock` degrades to an existence check and exits 0. So the `uv-lock` hook overrides it with `entry: env UV_FROZEN=false uv lock`. Drift then surfaces in exactly one place: the hook fails with "files were modified by this hook", and autofix.ci commits the corrected lock back. Every other `uv` call stays quiet.

`UV_LOCKED` was the alternative. It would scatter "lockfile needs to be updated" across every test job, and stop autofix from repairing the lock at all, since uv would refuse to write.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [ ] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [x] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the autofix workflow to use frozen dependency resolution for more consistent automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->