### PR TITLE
Fix worker shutdown hanging on side tasks that ignore cancellation

### DIFF
--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -212,6 +212,10 @@ class AwaitableContext(Generic[U]):
         return _inner_coro().__await__()
 
 
+CANCEL_ATTEMPTS = 5
+CANCEL_TIMEOUT = 1
+
+
 async def cancel_and_capture_errors(tasks: list[asyncio.Task[Any]]):
     """
     Cancel all tasks and capture any error returned by any of those tasks (except the CancellationError itself)
@@ -226,8 +230,40 @@ async def cancel_and_capture_errors(tasks: list[asyncio.Task[Any]]):
             },
         )
 
+    if not tasks:
+        return
+
     for task in tasks:
         task.cancel()
+
+    # A cancellation is lost if it lands just as the task takes its first step: the
+    # task then keeps looping and gather() below would wait for it for ever, since a
+    # side task only wakes on its own schedule (up to a whole cron period away).
+    # Re-cancel until the tasks really stop.
+    for _attempt in range(CANCEL_ATTEMPTS):
+        _done, pending = await asyncio.wait(tasks, timeout=CANCEL_TIMEOUT)
+        if not pending:
+            break
+        for task in pending:
+            logger.debug(
+                f"Task {task.get_name()} ignored its cancellation, cancelling again",
+                extra={"action": "cancel_task_again", "task_name": task.get_name()},
+            )
+            task.cancel()
+    else:
+        stuck = [task for task in tasks if not task.done()]
+        # Not raising: this runs in the run loop's finally, so an exception here
+        # would mask whatever caused the shutdown, and would turn a cancelled
+        # worker into an error rather than a CancelledError.
+        logger.error(
+            f"Abandoning tasks that did not stop when cancelled: "
+            f"{', '.join(task.get_name() for task in stuck)}",
+            extra={
+                "action": "cancel_tasks_failed",
+                "task_names": [task.get_name() for task in stuck],
+            },
+        )
+        return
 
     await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -230,49 +230,55 @@ async def cancel_and_capture_errors(tasks: list[asyncio.Task[Any]]):
             },
         )
 
+    def capture_errors(tasks: Iterable[asyncio.Task[Any]]):
+        for task in (task for task in tasks if task.done() and not task.cancelled()):
+            error = task.exception()
+            if error:
+                log_task_exception(task, error=error)
+            else:
+                logger.debug(f"Cancelled task {task.get_name()}")
+
     if not tasks:
         return
 
-    for task in tasks:
-        task.cancel()
-
     # A cancellation is lost if it lands just as the task takes its first step: the
-    # task then keeps looping and gather() below would wait for it for ever, since a
+    # task then keeps looping and waiting for it below would never return, since a
     # side task only wakes on its own schedule (up to a whole cron period away).
-    # Re-cancel until the tasks really stop.
-    for _attempt in range(CANCEL_ATTEMPTS):
-        _done, pending = await asyncio.wait(tasks, timeout=CANCEL_TIMEOUT)
+    # Cancel again on every round, so each cancellation gets its own chance to be
+    # acted upon.
+    pending: set[asyncio.Task[Any]] = set(tasks)
+    for attempt in range(CANCEL_ATTEMPTS):
+        for task in pending:
+            if attempt:
+                logger.debug(
+                    f"Task {task.get_name()} ignored its cancellation, cancelling again",
+                    extra={"action": "cancel_task_again", "task_name": task.get_name()},
+                )
+            task.cancel()
+
+        _done, pending = await asyncio.wait(pending, timeout=CANCEL_TIMEOUT)
         if not pending:
             break
-        for task in pending:
-            logger.debug(
-                f"Task {task.get_name()} ignored its cancellation, cancelling again",
-                extra={"action": "cancel_task_again", "task_name": task.get_name()},
-            )
-            task.cancel()
     else:
-        stuck = [task for task in tasks if not task.done()]
+        # The tasks that did stop may have something to report, and their exceptions
+        # would otherwise never be retrieved.
+        capture_errors(task for task in tasks if task not in pending)
         # Not raising: this runs in the run loop's finally, so an exception here
         # would mask whatever caused the shutdown, and would turn a cancelled
         # worker into an error rather than a CancelledError.
         logger.error(
             f"Abandoning tasks that did not stop when cancelled: "
-            f"{', '.join(task.get_name() for task in stuck)}",
+            f"{', '.join(sorted(task.get_name() for task in pending))}",
             extra={
                 "action": "cancel_tasks_failed",
-                "task_names": [task.get_name() for task in stuck],
+                "task_names": sorted(task.get_name() for task in pending),
             },
         )
         return
 
     await asyncio.gather(*tasks, return_exceptions=True)
 
-    for task in (task for task in tasks if task.done() and not task.cancelled()):
-        error = task.exception()
-        if error:
-            log_task_exception(task, error=error)
-        else:
-            logger.debug(f"Cancelled task {task.get_name()}")
+    capture_errors(tasks)
 
 
 async def wait_any(*coros_or_futures: Coroutine[Any, Any, Any] | asyncio.Future[Any]):

--- a/tests/integration/contrib/django/test_models.py
+++ b/tests/integration/contrib/django/test_models.py
@@ -115,19 +115,35 @@ async def test_procrastinate_periodic_defers(db):
     def my_task(timestamp):
         pass
 
+    async def list_periodic_defers():
+        return [
+            element
+            async for element in models.ProcrastinatePeriodicDefer.objects.values().all()
+        ]
+
+    async def wait_for_periodic_defer():
+        while not await list_periodic_defers():
+            await asyncio.sleep(0.01)
+
     django_app = procrastinate.contrib.django.app
     with django_app.replace_connector(
         django_app.connector.get_worker_connector()
     ) as app:
         async with app.open_async():
+            worker = asyncio.create_task(app.run_worker_async())
             try:
-                await asyncio.wait_for(app.run_worker_async(), timeout=0.1)
-            except asyncio.TimeoutError:
-                pass
+                # Run the worker until the deferrer has actually written its row.
+                # Giving it a fixed budget instead makes the test depend on worker
+                # startup fitting in that window, which it doesn't on a loaded runner.
+                await asyncio.wait_for(wait_for_periodic_defer(), timeout=5)
+            finally:
+                worker.cancel()
+                try:
+                    await worker
+                except asyncio.CancelledError:
+                    pass
 
-    periodic_defers = []
-    async for element in models.ProcrastinatePeriodicDefer.objects.values().all():
-        periodic_defers.append(element)
+    periodic_defers = await list_periodic_defers()
 
     assert periodic_defers[-1]["periodic_id"] == "bar"
     assert periodic_defers[-1]["task_name"] == "foo"

--- a/tests/integration/contrib/django/test_models.py
+++ b/tests/integration/contrib/django/test_models.py
@@ -138,8 +138,10 @@ async def test_procrastinate_periodic_defers(db):
                 await asyncio.wait_for(wait_for_periodic_defer(), timeout=5)
             finally:
                 worker.cancel()
+                # Bounded, so that a worker refusing to shut down fails the test
+                # instead of hanging the job until CI's own timeout.
                 try:
-                    await worker
+                    await asyncio.wait_for(worker, timeout=10)
                 except asyncio.CancelledError:
                     pass
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -411,6 +411,68 @@ async def test_cancel_and_capture_errors__task_swallows_first_cancellation(mocke
     assert tasks[0].cancelled()
 
 
+async def test_cancel_and_capture_errors__task_stops_on_last_attempt(mocker):
+    mocker.patch.object(utils, "CANCEL_TIMEOUT", 0.01)
+    mocker.patch.object(utils, "CANCEL_ATTEMPTS", 3)
+    cancellations = 0
+
+    async def late_task():
+        nonlocal cancellations
+        while True:
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                cancellations += 1
+                # Stops only on the last cancellation we're willing to send
+                if cancellations == 3:
+                    raise
+
+    tasks = [asyncio.create_task(late_task(), name="late")]
+    await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(utils.cancel_and_capture_errors(tasks), timeout=5)
+
+    assert cancellations == 3
+    assert tasks[0].cancelled()
+
+
+async def test_cancel_and_capture_errors__captures_errors_despite_stuck_task(
+    caplog, mocker
+):
+    caplog.set_level(logging.ERROR)
+    mocker.patch.object(utils, "CANCEL_TIMEOUT", 0.01)
+    mocker.patch.object(utils, "CANCEL_ATTEMPTS", 2)
+    release = asyncio.Event()
+
+    async def failing_task():
+        raise ValueError("Nope from failing_task")
+
+    async def unkillable_task():
+        while True:
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                if release.is_set():
+                    raise
+
+    tasks = [
+        asyncio.create_task(failing_task(), name="failing"),
+        asyncio.create_task(unkillable_task(), name="unkillable"),
+    ]
+    await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(utils.cancel_and_capture_errors(tasks), timeout=5)
+
+    # A task refusing to stop must not hide another task's error
+    assert "Nope from failing_task" in caplog.text
+    assert "unkillable" in caplog.text
+
+    release.set()
+    tasks[1].cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await tasks[1]
+
+
 async def test_cancel_and_capture_errors__task_never_stops(caplog, mocker):
     caplog.set_level(logging.ERROR)
     mocker.patch.object(utils, "CANCEL_TIMEOUT", 0.01)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import datetime
 import functools
 import logging
@@ -383,6 +384,65 @@ async def test_cancel_and_capture_errors(task_1_error, task_2_error, caplog):
     expected_error_count = sum(1 for error in (task_1_error, task_2_error) if error)
 
     assert len(caplog.records) == expected_error_count
+
+
+async def test_cancel_and_capture_errors__task_swallows_first_cancellation(mocker):
+    # A side task can miss its cancellation when it lands as the task takes its
+    # first step. It then goes back to sleep until its next tick, which can be a
+    # whole cron period away, and an unbounded wait would hang the shutdown.
+    mocker.patch.object(utils, "CANCEL_TIMEOUT", 0.01)
+    swallowed = asyncio.Event()
+
+    async def stubborn_task():
+        while True:
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                if swallowed.is_set():
+                    raise
+                swallowed.set()
+
+    tasks = [asyncio.create_task(stubborn_task(), name="stubborn")]
+    await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(utils.cancel_and_capture_errors(tasks), timeout=5)
+
+    assert swallowed.is_set()
+    assert tasks[0].cancelled()
+
+
+async def test_cancel_and_capture_errors__task_never_stops(caplog, mocker):
+    caplog.set_level(logging.ERROR)
+    mocker.patch.object(utils, "CANCEL_TIMEOUT", 0.01)
+    mocker.patch.object(utils, "CANCEL_ATTEMPTS", 2)
+
+    # Lets the test reap the task once it has made its point
+    release = asyncio.Event()
+
+    async def unkillable_task():
+        while True:
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                if release.is_set():
+                    raise
+
+    tasks = [asyncio.create_task(unkillable_task(), name="unkillable")]
+    await asyncio.sleep(0.01)
+
+    # Gives up rather than hanging for ever
+    await asyncio.wait_for(utils.cancel_and_capture_errors(tasks), timeout=5)
+
+    assert "unkillable" in caplog.text
+
+    release.set()
+    tasks[0].cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await tasks[0]
+
+
+async def test_cancel_and_capture_errors__no_task():
+    await utils.cancel_and_capture_errors([])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## The bug

`Worker._shutdown` cancels its side tasks and then awaits them with no bound, at
`utils.cancel_and_capture_errors`:

```python
for task in tasks:
    task.cancel()
await asyncio.gather(*tasks, return_exceptions=True)
```

A cancellation can be **lost** when it lands just as the task takes its first step.
Tracing the periodic deferrer's own methods at the moment of the hang:

```
>>> cancelling worker now      <- cancel requested
defer_jobs: enter              <- deferrer's first tick runs anyway
defer_jobs: returned
wait: enter next_tick=29.852   <- sleeps until the next cron minute
deferrer cancelling=1          <- cancel was requested, and swallowed
```

The task reports `cancelling=1` while parked on a *fresh, uncancelled* future inside
`asyncio.sleep`, so the `gather` waits for a task that only wakes on its own cron
schedule — and once awake it just loops and sleeps again.

**It hangs permanently, not until the next tick.** 3 of 12 runs were still stuck after
120 s despite a ~30 s sleep.

Two things make this worse than it looks:

- It is reachable from any cancellation-based shutdown, including the documented
  `asyncio.wait_for(app.run_worker_async(), timeout=...)`. `Worker.run` deliberately
  converts a cancellation into a graceful stop (shield the loop, then `stop()` +
  `await loop_task`), so the hanging gather blocks that path for good.
- All three side tasks share the vulnerable `while True: await asyncio.sleep(...)`
  shape — `_update_heartbeat` and `_poll_jobs_to_abort` as well as the deferrer. The
  deferrer merely has the longest sleep, so it is the one that shows up. The fix is
  therefore generic rather than deferrer-specific.

## The fix

Re-cancel while tasks are still pending. The second cancellation lands on an ordinary
`asyncio.sleep` and takes effect. After `CANCEL_ATTEMPTS` (5 × 1 s) it gives up and
logs rather than hanging.

It **logs instead of raising** on the give-up path, deliberately: `_shutdown` runs in
the run loop's `finally`, so raising would supersede whatever caused the shutdown, and
it would make a cancelled worker surface a `RuntimeError` instead of a
`CancelledError` — which would break `asyncio.wait_for(...)` no longer raising
`TimeoutError`. It also matches the existing contract of a function that already logs
task exceptions rather than raising them.

Free on the happy path: `asyncio.wait` returns as soon as the tasks finish, so normal
shutdown latency is unchanged.

## Verification

- **The real race, instrumented:** it fired in **5 of 16 runs** and recovered every
  time, 0 hangs. Same harness and timing that previously hung.
- **Deterministic unit tests:** a task that swallows its first cancellation (asserting
  the helper returns and the task ends cancelled), the give-up path, and the
  empty-list case — `asyncio.wait` raises on an empty set, so that needed a guard.
- Full suite passes.

## Second commit: the flaky test that found this

`test_procrastinate_periodic_defers` gave the worker a fixed 0.1 s to start up and let
the deferrer write its row, then did `periodic_defers[-1]`, so a slow runner got
`IndexError` instead of a useful message. It now waits for the row instead.

That change **depends on the first commit**: waiting for the row means cancelling
during startup, which is precisely when the cancellation could be lost. On its own it
hung 2 runs in 8; with the fix it passes 16/16 with the race hit 4 times and recovered
each time.

Seen in CI on [this run](https://github.com/procrastinate-org/procrastinate/actions/runs/32071502440/job/95515531065).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task cancellation reliability by retrying cancellation for pending tasks.
  * Captures errors from tasks that stop during cleanup and logs tasks that remain active after five attempts.
  * Preserves error handling for completed tasks and gracefully handles empty task lists.

* **Tests**
  * Added coverage for cancellation retries, unresponsive tasks, cleanup, and empty task lists.
  * Improved reliability when shutting down workers in integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->