### PR TITLE
Compare heartbeats against the database clock, not the local one

### DIFF
--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -5,7 +5,7 @@ import functools
 
 import pytest
 
-from procrastinate import exceptions, jobs, manager, utils
+from procrastinate import exceptions, jobs, manager
 
 from .. import conftest
 
@@ -320,9 +320,13 @@ async def test_register_and_unregister_worker(pg_job_manager, psycopg_connector)
     rows = await psycopg_connector.execute_query_all_async(
         f"SELECT * FROM procrastinate_workers WHERE id={worker_id}"
     )
+    now = await psycopg_connector.execute_query_one_async(
+        "SELECT clock_timestamp() AS now"
+    )
+
     assert len(rows) == 1
     assert rows[0]["id"] == worker_id
-    assert abs((rows[0]["last_heartbeat"] - utils.utcnow()).total_seconds()) < 0.1
+    assert abs((rows[0]["last_heartbeat"] - now["now"]).total_seconds()) < 0.1
 
     await pg_job_manager.unregister_worker(worker_id=worker_id)
 
@@ -343,9 +347,17 @@ async def test_update_heartbeat(pg_job_manager, psycopg_connector, worker_id):
     rows = await psycopg_connector.execute_query_all_async(
         f"SELECT * FROM procrastinate_workers WHERE id={worker_id}"
     )
+    # The heartbeat is stamped by the database, so the upper bound has to come from
+    # the database too: when Postgres runs in a container, its clock can sit a few
+    # milliseconds ahead of the host's, which is enough to make a comparison against
+    # the local clock fail.
+    now = await psycopg_connector.execute_query_one_async(
+        "SELECT clock_timestamp() AS now"
+    )
+
     assert len(rows) == 1
     assert rows[0]["id"] == worker_id
-    assert first_heartbeat < rows[0]["last_heartbeat"] < utils.utcnow()
+    assert first_heartbeat < rows[0]["last_heartbeat"] < now["now"]
 
 
 async def test_prune_stalled_workers(pg_job_manager, psycopg_connector, worker_id):


### PR DESCRIPTION
Both worker-registration assertions in `tests/integration/test_manager.py` took the timestamp Postgres had stamped on the row and compared it against the host's clock:

```python
assert first_heartbeat < rows[0]["last_heartbeat"] < utils.utcnow()
assert abs((rows[0]["last_heartbeat"] - utils.utcnow()).total_seconds()) < 0.1
```

When Postgres runs in a container its clock can drift from the host's, and the comparison then fails for reasons unrelated to the code under test:

```
AssertionError: assert datetime.datetime(2026, 8, 19, 20, 44, 36, 938737, tzinfo=ZoneInfo('Etc/UTC'))
                    < datetime.datetime(2026, 8, 19, 20, 44, 36, 934935, tzinfo=timezone.utc)
```

Measured locally against a podman-hosted Postgres, comparing the database timestamp with a host timestamp taken *after* the query returned, so round-trip is excluded:

```
host before : 07:11:00.289232+00:00
db          : 07:11:00.360311+00:00
host after  : 07:11:00.294735+00:00
db - host_after = +65.58 ms
```

66 ms of drift fails `test_update_heartbeat` outright. It also leaves `test_register_and_unregister_worker` with 34 ms of its 100 ms tolerance, so that one is a little more drift away from failing for the same reason — hence both are changed here.

The fix takes the upper bound from `clock_timestamp()` so both sides of the comparison come from the same clock. The assertions keep their meaning (the heartbeat advanced, and it is not in the future), they just stop depending on two machines agreeing on the time. `utils` became unused in the module and was dropped from the imports.

CI never saw this because its Postgres service shares the runner's clock; it only bites local runs against a containerised database. With this, the full suite passes locally (877 passed) where it previously had this one failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated worker registration and heartbeat integration tests to compare against database-generated timestamps.
  * Removed an unused test dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->