### PR TITLE
Wait for the signal handler before signalling the worker

### DIFF
--- a/tests/integration/test_wait_stop.py
+++ b/tests/integration/test_wait_stop.py
@@ -1,11 +1,30 @@
 from __future__ import annotations
 
 import asyncio
+import signal
 
 import pytest
 
 from procrastinate import app
 from procrastinate import worker as worker_module
+
+
+async def wait_for_signal_handler(sig: signal.Signals, previous, timeout: float = 5):
+    """
+    Wait until the worker has installed its handler for `sig`, i.e. until the signal
+    has stopped being fatal to this process.
+
+    asyncio's add_signal_handler() also registers a placeholder through
+    signal.signal(), so the disposition changing is what tells us the signal is now
+    handled. Should that ever stop being true, this times out and fails the test
+    rather than letting the signal kill the test process.
+    """
+
+    async def poll():
+        while signal.getsignal(sig) is previous:
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(poll(), timeout)
 
 
 async def test_wait_for_activity_cancelled(psycopg_connector):
@@ -44,7 +63,14 @@ async def test_wait_for_activity_stop_from_signal(psycopg_connector, kill_own_pi
     """
     pg_app = app.App(connector=psycopg_connector)
     worker = worker_module.Worker(app=pg_app, fetch_job_polling_interval=2)
+    # The worker installs its signal handler only after registering itself in the
+    # database. Until then SIGTERM is fatal, so betting a fixed delay on those
+    # queries means a slow database kills the test process (exit code 143) instead
+    # of failing the test.
+    previous_handler = signal.getsignal(signal.SIGTERM)
     task = asyncio.ensure_future(worker.run())
+    await wait_for_signal_handler(signal.SIGTERM, previous_handler)
+
     await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
     kill_own_pid()

--- a/tests/integration/test_wait_stop.py
+++ b/tests/integration/test_wait_stop.py
@@ -73,6 +73,16 @@ async def test_wait_for_activity_stop_from_signal(psycopg_connector, kill_own_pi
 
     await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
+    # The worker uninstalls its handler on the way out, so a worker that died
+    # during the sleep above would leave SIGTERM fatal again. Check right before
+    # signalling, without awaiting in between, so that we report what the worker
+    # did instead of being killed by the signal.
+    if task.done():
+        task.result()  # re-raises whatever killed the worker, if anything did
+        pytest.fail("Worker stopped before it could be signalled")
+    if signal.getsignal(signal.SIGTERM) is previous_handler:
+        pytest.fail("Worker uninstalled its signal handler before being signalled")
+
     kill_own_pid()
 
     try:


### PR DESCRIPTION
## The bug

`test_wait_for_activity_stop_from_signal` starts a worker, waits 0.2 s, then sends **SIGTERM to its own process**:

```python
task = asyncio.ensure_future(worker.run())
await asyncio.sleep(0.2)  # should be enough so that we're waiting
kill_own_pid()            # SIGTERM
```

The worker installs its handler inside `_run_loop`, under `with signals.on_stop(...)` — which is reached only *after* `run()` has pruned stalled workers and registered the worker, i.e. after two database round-trips. If those overrun the 0.2 s, SIGTERM is still at its default disposition and kills the interpreter rather than stopping the worker.

That is what happened on [this job](https://github.com/procrastinate-org/procrastinate/actions/runs/32303893185/job/96232348517): the step ends with

```
tests/integration/test_wait_stop.py::test_wait_for_activity_stop_from_signal
##[error]Process completed with exit code 143
```

143 is SIGTERM, so it does not fail as a test — pytest never gets to report anything. And because the `tests` matrix has no `fail-fast: false`, the first version to hit it cancels the other four, so a single flake shows up as all five Python versions red with "The operation was canceled". That reads as "everything is broken" and costs a full re-run to disprove.

## The fix

Wait for SIGTERM to actually be handled before sending it. asyncio's `add_signal_handler()` also registers a placeholder via `signal.signal()`, so the disposition changing is a direct observation of "this signal can no longer kill us":

```
before add_signal_handler : 0                  (SIG_DFL)
after  add_signal_handler : <function _sighandler_noop>
```

If that ever stops being true, the helper times out and fails the test instead of letting the signal kill the process — loud rather than fatal.

## Verification

Probing the fatal window directly, by varying the delay between starting the worker and signalling:

| delay before signal | without the guard | with the guard |
|---|---|---|
| 0 s | **exit 143** | exit 0 |
| 0.001 s | **exit 143** | exit 0 |
| 0.01 s | exit 0 | exit 0 |
| 0.2 s | exit 0 | exit 0 |

So the guard removes the fatal window entirely, rather than just making it less likely. `test_wait_stop.py` also runs 12/12 clean.

The 0.2 s sleep is kept — the test is about interrupting the polling wait, and that is what the delay is for. The difference is that overshooting it can now only make the test weaker, never fatal.

## Scope

Only this test had the racy shape. The `tests/unit/test_signals.py` cases send their signals inside the `signals.on_stop(...)` block, so the handler is already installed, and `test_run_no_signal_handlers` deliberately asserts the *absence* of a handler using SIGINT, whose default raises a catchable `KeyboardInterrupt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved shutdown test reliability by waiting for the worker’s termination handler to initialize before sending a stop signal.
  - Added a timeout so the test fails clearly if initialization does not complete, instead of risking process termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->