### PR TITLE
Give the zipball download a timeout and retry it

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -68,14 +68,28 @@ def current_version_without_post_migration(session: nox.Session):
     )
 
 
+# Downloading a whole repository zipball routinely takes longer than httpx's
+# 5 second default, and the read timing out fails the whole session.
+ZIPBALL_TIMEOUT = 60
+ZIPBALL_ATTEMPTS = 3
+
+
 def get_zip_repo(client: httpx.Client, ref: str) -> zipfile.ZipFile:
-    response = client.get(
-        f"https://api.github.com/repos/procrastinate-org/procrastinate/zipball/{ref}",
-        headers={"Accept": "application/vnd.github+json"},
-        follow_redirects=True,
-    )
-    response.raise_for_status()
-    return zipfile.ZipFile(io.BytesIO(response.content))
+    for attempt in range(ZIPBALL_ATTEMPTS):
+        try:
+            response = client.get(
+                f"https://api.github.com/repos/procrastinate-org/procrastinate/zipball/{ref}",
+                headers={"Accept": "application/vnd.github+json"},
+                follow_redirects=True,
+            )
+            response.raise_for_status()
+        except (httpx.TransportError, httpx.HTTPStatusError) as exc:
+            if attempt == ZIPBALL_ATTEMPTS - 1:
+                raise
+            print(f"Fetching the {ref} zipball failed ({exc!r}), retrying")
+            continue
+        return zipfile.ZipFile(io.BytesIO(response.content))
+    raise AssertionError("unreachable")
 
 
 PIN_PYTHON: str | None = None
@@ -99,7 +113,7 @@ def stable_version_without_post_migration(session: nox.Session):
         except KeyError:
             headers = {}
 
-        client = httpx.Client(headers=headers)
+        client = httpx.Client(headers=headers, timeout=ZIPBALL_TIMEOUT)
 
         zip_repo = get_zip_repo(client=client, ref=str(latest_tag))
 


### PR DESCRIPTION
`get_zip_repo` fetches a whole repository archive through a client built as `httpx.Client(headers=headers)` — no timeout, so httpx's **5 second default** applies to the read. That is not much for a repository archive, and exceeding it fails the session outright:

```
nox > cd /tmp/tmpaeje2f2x
nox > Session stable_version_without_post_migration raised exception ReadTimeout('The read operation timed out')
  File ".../noxfile.py", line 72, in get_zip_repo
    response = client.get(
```

Seen on [this job](https://github.com/procrastinate-org/procrastinate/actions/runs/32558289074). The client now gets a 60 s timeout, and the download is retried, since a transport error here is unrelated to what the session is testing.

Verified against the real endpoint: the download takes 1.4 s for 400 entries here, so 5 s is close enough to normal to be hit under load. The retry was exercised with an injected failure rather than left as untested code:

```
2 failures     -> recovered after 3 calls, 400 entries
always failing -> raised ReadTimeout after 3 calls
```

So it recovers within budget and still propagates once exhausted.

No library code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when downloading repository archives.
  * Failed downloads are now retried automatically, with clearer retry feedback.
  * Added a timeout to prevent requests from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->