### PR TITLE
Wait for the lock holder to be running in test_lock

### DIFF
--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import signal
 import subprocess
 import time
+from collections.abc import Iterator
 from typing import Protocol
 
 import pytest
@@ -32,24 +34,32 @@ def worker(running_worker) -> Worker:
 
 
 @pytest.fixture
-def running_worker(process_env) -> RunningWorker:
-    def func(*queues, name="worker", app="app"):
-        return subprocess.Popen(
-            [
-                "procrastinate",
-                "-vvv",
-                "worker",
-                f"--name={name}",
-                "--queues",
-                ",".join(queues),
-            ],
-            env=process_env(app=app),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            encoding="utf-8",
-        )
+def running_worker(process_env) -> Iterator[RunningWorker]:
+    # Workers only exit on a signal, so a test failing before it stops the ones it
+    # started would leave them running. Popen's own context manager closes the pipes
+    # and waits, which would hang here, so a kill is registered to unwind first.
+    with contextlib.ExitStack() as stack:
 
-    return func
+        def func(*queues, name="worker", app="app"):
+            process = subprocess.Popen(
+                [
+                    "procrastinate",
+                    "-vvv",
+                    "worker",
+                    f"--name={name}",
+                    "--queues",
+                    ",".join(queues),
+                ],
+                env=process_env(app=app),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                encoding="utf-8",
+            )
+            stack.enter_context(process)
+            stack.callback(process.kill)
+            return process
+
+        yield func
 
 
 @pytest.mark.parametrize("app", ["app", "app_aiopg"])

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -127,7 +127,24 @@ def test_task_with_default_priority(defer, worker, app):
     assert stderr.startswith("DEBUG:procrastinate.")
 
 
-def test_lock(defer, running_worker):
+def wait_for_jobs(connector, status: str, count: int, timeout: float = 10):
+    """
+    Wait until `count` jobs have reached `status`.
+    """
+    rows = []
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        rows = connector.execute_query_all(
+            "SELECT id FROM procrastinate_jobs WHERE status=%(status)s", status=status
+        )
+        if len(rows) >= count:
+            return
+        time.sleep(0.01)
+
+    pytest.fail(f"Only {len(rows)} job(s) reached status {status}, expected {count}")
+
+
+def test_lock(defer, running_worker, sync_psycopg_connector):
     """
     In this test, we launch 2 workers in two parallel threads, and ask them
     both to process tasks with the same lock. We check that the second task is
@@ -145,7 +162,13 @@ def test_lock(defer, running_worker):
     # Run the 2 workers concurrently
     process1 = running_worker(name="worker1")
     process2 = running_worker(name="worker2")
-    time.sleep(0.1)
+
+    # The second task has the higher priority, so it wins the fetch if it is
+    # deferred while the first one is still waiting in the queue, and the test then
+    # sees the two tasks in the other order. What we mean to test is that a task
+    # *holding* the lock delays the other one, so wait for the first task to be
+    # running rather than assuming the workers boot within a fixed delay.
+    wait_for_jobs(sync_psycopg_connector, status="doing", count=1)
 
     defer(
         "sleep_and_write",
@@ -155,7 +178,7 @@ def test_lock(defer, running_worker):
         write_after="after-2",
     )
 
-    time.sleep(1)
+    wait_for_jobs(sync_psycopg_connector, status="succeeded", count=2)
     # And stop them
     process1.send_signal(signal.SIGINT)
     process2.send_signal(signal.SIGINT)


### PR DESCRIPTION
## The bug

`test_lock` defers a task with priority 1 holding lock `a`, starts two workers, waits **0.1 s**, then defers a task with priority 2 holding the same lock, and asserts the first ran to completion before the second started.

That 0.1 s is a bet on both workers having booted. Lose it and the second task is deferred while the first is *still queued* — where the higher priority wins the fetch. The second task then runs first, and the lock correctly delays the first:

```
assert ['before-2', 'after-2', 'before-1', 'after-1']
    == ['before-1', 'after-1', 'before-2', 'after-2']
```

Note what this means: **the lock worked correctly**. What broke was the test's premise. The docstring says "irrespective of the task priority", but that only holds once the first task is actually *holding* the lock — while it is merely queued, priority is exactly what decides the order.

Seen on [main in June](https://github.com/procrastinate-org/procrastinate/actions/runs/27967485370) and again this week on an unrelated PR's e2e job, where it cost a re-run to establish it was unrelated.

## The fix

Wait for the first task to reach `doing` before deferring the second, using the `sync_psycopg_connector` fixture — which points at the same database as the CLI subprocesses, since `process_env` passes the same `dbname`.

The trailing `time.sleep(1)` is replaced by a wait for both jobs to succeed, so the assertion no longer depends on the second task finishing inside a one second window either. Both fixed delays in the test are now gone.

## Verification

Reproducing the failure by varying the bet, then comparing strategies:

| pre-defer wait | old (fixed sleep) | new (wait for `doing`) |
|---|---|---|
| 0 s | **order inverted** | pass |
| 0.02 s | pass | pass |
| 0.1 s (current) | pass | pass |

So the failure mode is reproducible on demand and the new approach cannot hit it: the second task is only deferred once the first holds the lock. `test_lock` also runs 8/8, the acceptance directory 57/57, and the full suite is unchanged.

## On the rest of the flake list

While looking into this I checked the two other acceptance tests I had flagged earlier. Both were already de-flaked by `fa5a0385`, `9b4dc489` and `08260803` — `test_stop_worker_aborts_sync_jobs_past_shutdown_graceful_timeout` now waits on job status rather than sleeping, and `test_sync_task_runs_in_parallel` was rewritten to assert overlap. My evidence for those was from June and stale, so there is nothing to do there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved acceptance test reliability by ensuring worker processes are properly tracked and cleaned up after each test.
  * Added managed process lifecycle handling to prevent lingering workers and resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->