### PR TITLE
Add a deferred_at column to jobs

### DIFF
--- a/procrastinate/contrib/django/migrations/0042_pre_add_deferred_at.py
+++ b/procrastinate/contrib/django/migrations/0042_pre_add_deferred_at.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+
+from .. import migrations_utils
+
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations_utils.RunProcrastinateSQL(
+            name="03.10.00_01_pre_add_deferred_at.sql"
+        ),
+        migrations.AddField(
+            "procrastinatejob",
+            "deferred_at",
+            models.DateTimeField(blank=True, null=True),
+        ),
+    ]
+    name = "0042_pre_add_deferred_at"
+    dependencies = [
+        ("procrastinate", "0041_post_retry_failed_job"),
+    ]

--- a/procrastinate/contrib/django/models.py
+++ b/procrastinate/contrib/django/models.py
@@ -97,6 +97,7 @@ class ProcrastinateJob(ProcrastinateReadOnlyModelMixin, models.Model):
     worker = models.ForeignKey(
         ProcrastinateWorker, on_delete=models.SET_NULL, blank=True, null=True
     )
+    deferred_at = models.DateTimeField(blank=True, null=True)
 
     objects = ProcrastinateReadOnlyManager()
 
@@ -118,6 +119,7 @@ class ProcrastinateJob(ProcrastinateReadOnlyModelMixin, models.Model):
             attempts=self.attempts,
             abort_requested=self.abort_requested,
             queueing_lock=self.queueing_lock,
+            deferred_at=self.deferred_at,
         )
 
     def __str__(self) -> str:

--- a/procrastinate/jobs.py
+++ b/procrastinate/jobs.py
@@ -100,9 +100,7 @@ class Job:
     #: ID of the worker that is processing the job
     worker_id: int | None = None
     #: Date and time when the job was deferred.
-    deferred_at: datetime.datetime | None = attr.ib(
-        default=None, validator=check_aware
-    )
+    deferred_at: datetime.datetime | None = attr.ib(default=None, validator=check_aware)
 
     @classmethod
     def from_row(cls, row: dict[str, Any]) -> Job:

--- a/procrastinate/jobs.py
+++ b/procrastinate/jobs.py
@@ -99,6 +99,10 @@ class Job:
     abort_requested: bool = False
     #: ID of the worker that is processing the job
     worker_id: int | None = None
+    #: Date and time when the job was deferred.
+    deferred_at: datetime.datetime | None = attr.ib(
+        default=None, validator=check_aware
+    )
 
     @classmethod
     def from_row(cls, row: dict[str, Any]) -> Job:
@@ -115,6 +119,7 @@ class Job:
             attempts=row["attempts"],
             abort_requested=row.get("abort_requested", False),
             worker_id=row.get("worker_id"),
+            deferred_at=row.get("deferred_at"),
         )
 
     def asdict(self) -> dict[str, Any]:
@@ -125,6 +130,9 @@ class Job:
 
         if context["scheduled_at"]:
             context["scheduled_at"] = context["scheduled_at"].isoformat()
+
+        if context["deferred_at"]:
+            context["deferred_at"] = context["deferred_at"].isoformat()
 
         context["call_string"] = self.call_string
         return context

--- a/procrastinate/sql/migrations/03.10.00_01_pre_add_deferred_at.sql
+++ b/procrastinate/sql/migrations/03.10.00_01_pre_add_deferred_at.sql
@@ -1,0 +1,5 @@
+-- add a deferred_at column to the procrastinate_jobs table
+-- (added without a default first so that pre-existing jobs keep NULL
+-- instead of being backfilled with the migration timestamp)
+ALTER TABLE procrastinate_jobs ADD COLUMN deferred_at timestamp with time zone;
+ALTER TABLE procrastinate_jobs ALTER COLUMN deferred_at SET DEFAULT NOW();

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -18,13 +18,13 @@ SELECT procrastinate_defer_periodic_job_v2(%(queue)s, %(lock)s, %(queueing_lock)
 
 -- fetch_job --
 -- Get the first awaiting job
-SELECT id, status, task_name, priority, lock, queueing_lock, args, scheduled_at, queue_name, attempts, worker_id
+SELECT id, status, task_name, priority, lock, queueing_lock, args, scheduled_at, queue_name, attempts, worker_id, deferred_at
     FROM procrastinate_fetch_job_v2(%(queues)s::varchar[], %(worker_id)s);
 
 -- select_stalled_jobs_by_started --
 -- Get running jobs that started more than a given time ago
 SELECT job.id, status, task_name, priority, lock, queueing_lock,
-       args, scheduled_at, queue_name, attempts, worker_id,
+       args, scheduled_at, queue_name, attempts, worker_id, deferred_at,
        MAX(event.at) AS started_at
     FROM procrastinate_jobs job
     JOIN procrastinate_events event
@@ -44,7 +44,7 @@ WITH stalled_workers AS (
     WHERE last_heartbeat < NOW() - (%(seconds_since_heartbeat)s || ' SECOND')::INTERVAL
 )
 SELECT job.id, status, task_name, priority, lock, queueing_lock,
-       args, scheduled_at, queue_name, attempts, job.worker_id
+       args, scheduled_at, queue_name, attempts, job.worker_id, deferred_at
   FROM procrastinate_jobs job
  LEFT JOIN stalled_workers sw ON sw.id = job.worker_id
  WHERE job.status = 'doing'
@@ -109,7 +109,8 @@ SELECT id,
        scheduled_at,
        attempts,
        abort_requested,
-       worker_id
+       worker_id,
+       deferred_at
   FROM procrastinate_jobs
  WHERE (%(id)s::bigint IS NULL OR id = %(id)s)
    AND (%(queue_name)s::varchar IS NULL OR queue_name = %(queue_name)s)

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -75,6 +75,7 @@ CREATE TABLE procrastinate_jobs (
     attempts integer DEFAULT 0 NOT NULL,
     abort_requested boolean DEFAULT false NOT NULL,
     worker_id bigint REFERENCES procrastinate_workers(id) ON DELETE SET NULL,
+    deferred_at timestamp with time zone DEFAULT NOW(),
     CONSTRAINT check_not_todo_abort_requested CHECK (NOT (status = 'todo' AND abort_requested = true))
 );
 

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -183,6 +183,7 @@ class InMemoryConnector(connector.BaseAsyncConnector):
                 "attempts": 0,
                 "abort_requested": False,
                 "worker_id": None,
+                "deferred_at": utils.utcnow(),
             }
             self.events[id] = []
             if job.scheduled_at:

--- a/tests/integration/contrib/django/test_models.py
+++ b/tests/integration/contrib/django/test_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+from unittest import mock
 
 import pytest
 
@@ -30,6 +31,7 @@ def test_procrastinate_job(db):
         "queueing_lock": None,
         "abort_requested": False,
         "worker_id": None,
+        "deferred_at": mock.ANY,
     }
 
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -5,6 +5,7 @@ import dataclasses
 import datetime
 import logging
 import os
+from unittest import mock
 
 import pytest
 
@@ -171,6 +172,7 @@ async def test_defer(entrypoint, cli_app, connector):
             "priority": 0,
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         }
     }
 
@@ -198,6 +200,7 @@ async def test_defer_priority(entrypoint, cli_app, connector):
             "priority": 5,
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         }
     }
 
@@ -230,6 +233,7 @@ async def test_defer_at(entrypoint, cli_app, connector):
             "priority": 0,
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         }
     }
 
@@ -261,6 +265,7 @@ async def test_defer_in(entrypoint, cli_app, connector):
         "priority": 0,
         "abort_requested": False,
         "worker_id": None,
+        "deferred_at": mock.ANY,
     }
     assert (
         now + datetime.timedelta(seconds=9)
@@ -327,6 +332,7 @@ async def test_defer_unknown(entrypoint, cli_app, connector):
             "priority": 0,
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         }
     }
 

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -61,11 +61,14 @@ async def test_fetch_job(
     # Now add the job we're testing
     job = await deferred_job_factory(**job_kwargs)
 
-    expected_job = job.evolve(status="doing", worker_id=worker_id)
-    assert (
-        await pg_job_manager.fetch_job(queues=fetch_queues, worker_id=worker_id)
-        == expected_job
+    fetched_job = await pg_job_manager.fetch_job(
+        queues=fetch_queues, worker_id=worker_id
     )
+    assert fetched_job.deferred_at is not None
+    expected_job = job.evolve(
+        status="doing", worker_id=worker_id, deferred_at=fetched_job.deferred_at
+    )
+    assert fetched_job == expected_job
 
 
 async def test_fetch_job_not_fetching_started_job(
@@ -772,7 +775,9 @@ async def fixture_jobs(pg_job_manager, job_factory, worker_id):
 
 async def test_list_jobs_dict(fixture_jobs, pg_job_manager):
     j1, *_ = fixture_jobs
-    assert (await pg_job_manager.list_jobs_async())[0] == j1
+    listed_job = (await pg_job_manager.list_jobs_async())[0]
+    assert listed_job.deferred_at is not None
+    assert listed_job == j1.evolve(deferred_at=listed_job.deferred_at)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+from unittest import mock
 
 import pytest
 
@@ -44,6 +45,7 @@ def test_job_get_context(job_factory, scheduled_at, context_scheduled_at):
         "call_string": "mytask[12](a='b')",
         "abort_requested": False,
         "worker_id": None,
+        "deferred_at": None,
     }
 
 
@@ -83,6 +85,7 @@ async def test_job_deferrer_defer_async(job_factory, job_manager, connector):
             "task_name": "mytask",
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         }
     }
 

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
+from unittest import mock
 
 import pytest
 
@@ -42,6 +43,7 @@ async def test_manager_defer_job(job_manager, job_factory, connector):
             "task_name": "bla",
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         }
     }
 
@@ -84,6 +86,7 @@ async def test_manager_batch_defer_jobs(job_manager, job_factory, connector):
             "task_name": "bla",
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         },
         2: {
             "args": {"a": "c"},
@@ -98,6 +101,7 @@ async def test_manager_batch_defer_jobs(job_manager, job_factory, connector):
             "task_name": "bla",
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         },
     }
 
@@ -177,10 +181,15 @@ async def test_fetch_job_no_suitable_job(job_manager, worker_id):
     assert await job_manager.fetch_job(queues=None, worker_id=worker_id) is None
 
 
-async def test_fetch_job(job_manager, job_factory, worker_id):
+async def test_fetch_job(job_manager, job_factory, connector, worker_id):
     job = job_factory(id=None)
     await job_manager.defer_job_async(job=job)
-    expected_job = job.evolve(id=1, status="doing", worker_id=worker_id)
+    expected_job = job.evolve(
+        id=1,
+        status="doing",
+        worker_id=worker_id,
+        deferred_at=connector.jobs[1]["deferred_at"],
+    )
     assert await job_manager.fetch_job(queues=None, worker_id=worker_id) == expected_job
 
 
@@ -198,7 +207,12 @@ async def test_get_stalled_jobs_by_started_stalled(
     await job_manager.defer_job_async(job=job)
     await job_manager.fetch_job(queues=None, worker_id=worker_id)
     connector.events[1][-1]["at"] = conftest.aware_datetime(2000, 1, 1)
-    expected_job = job.evolve(id=1, status="doing", worker_id=worker_id)
+    expected_job = job.evolve(
+        id=1,
+        status="doing",
+        worker_id=worker_id,
+        deferred_at=connector.jobs[1]["deferred_at"],
+    )
     with pytest.warns(DeprecationWarning, match=".*nb_seconds.*"):
         assert await job_manager.get_stalled_jobs(nb_seconds=1000) == [expected_job]
 
@@ -216,7 +230,12 @@ async def test_get_stalled_jobs_by_heartbeat_stalled(
     await job_manager.defer_job_async(job=job)
     await job_manager.fetch_job(queues=None, worker_id=worker_id)
     connector.workers = {1: conftest.aware_datetime(2000, 1, 1)}
-    expected_job = job.evolve(id=1, status="doing", worker_id=worker_id)
+    expected_job = job.evolve(
+        id=1,
+        status="doing",
+        worker_id=worker_id,
+        deferred_at=connector.jobs[1]["deferred_at"],
+    )
     assert await job_manager.get_stalled_jobs() == [expected_job]
 
 
@@ -577,14 +596,16 @@ def test_retry_job_by_id(job_manager, connector, job_factory, dt):
     )
 
 
-async def test_list_jobs_async(job_manager, job_factory):
+async def test_list_jobs_async(job_manager, job_factory, connector):
     job = await job_manager.defer_job_async(job=job_factory())
+    job = job.evolve(deferred_at=connector.jobs[1]["deferred_at"])
 
     assert await job_manager.list_jobs_async() == [job]
 
 
-def test_list_jobs(job_manager, job_factory):
+def test_list_jobs(job_manager, job_factory, connector):
     job = job_manager.defer_job(job=job_factory())
+    job = job.evolve(deferred_at=connector.jobs[1]["deferred_at"])
 
     assert job_manager.list_jobs() == [job]
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
 
 from procrastinate import tasks, utils
@@ -40,6 +42,7 @@ async def test_task_defer_async(app: App, connector):
             "attempts": 0,
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         }
     }
 
@@ -65,6 +68,7 @@ async def test_task_batch_defer_async(app: App, connector):
             "attempts": 0,
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         },
         2: {
             "id": 2,
@@ -79,6 +83,7 @@ async def test_task_batch_defer_async(app: App, connector):
             "attempts": 0,
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": mock.ANY,
         },
     }
 

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -88,6 +88,7 @@ async def test_defer_one_job(connector: testing.InMemoryConnector):
             "attempts": 0,
             "abort_requested": False,
             "worker_id": None,
+            "deferred_at": ANY,
         }
     }
     assert connector.jobs[1] == jobs[0]


### PR DESCRIPTION
Adds a `deferred_at` timestamp to `procrastinate_jobs`, recording when a job was deferred, and exposes it as `Job.deferred_at`.

There's no existing issue for this, so nothing to close. Happy to open one first if you'd prefer that order.

### Motivation

The deferral time is currently only recoverable by joining `procrastinate_events` for the `deferred` row, which is awkward for the common cases of "how long has this job been waiting?" and sorting a queue by age. `scheduled_at` is a different thing (a "not before" time) and is `NULL` for most jobs.

### Implementation notes

The change leans on a SQL `DEFAULT NOW()` to stay small, which means:

- `procrastinate_defer_jobs_v1`, the `procrastinate_job_to_defer_v1` composite type, `types.JobToDefer` and the whole defer code path are **untouched** — no new function version, so no pre/post migration dance.
- The migration adds the column without a default first, then sets it, so pre-existing rows keep `NULL` rather than being backfilled with the migration's timestamp. A nullable added column is backward-compatible with the currently-released code, so this is a pre-migration only.

The rest is plumbing: `deferred_at` added to the four explicit SELECT lists in `queries.sql` (`fetch_job`, both stalled-job queries, `list_jobs`); an optional `Job.deferred_at` field read with `row.get()` in `from_row` for backward compatibility, and rendered in `log_context`; `InMemoryConnector` sets it on defer to mirror the DB; and the Django contrib gets the model field plus migration `0042`, following the `RunProcrastinateSQL` + `AddField` pattern from `0026_add_job_priority.py`.

One known limitation, flagged deliberately: the `Job` returned by `defer()` does not carry `deferred_at`, since the value is generated by the database and the defer function only returns ids. It's populated on fetched and listed jobs. Returning it from defer would need a `_v2` defer function; I left that out to keep the diff minimal, but I'm glad to add it if you'd rather the field were always populated.

### Testing

Full suite green locally against PostgreSQL 15: **883 passed, 8 deselected**, including `tests/migration` (both the schema-vs-migrations diff check and the naming check). Existing assertions were updated for the new field, and the integration tests now additionally assert that the database actually populates `deferred_at` on defer (`test_fetch_job`, `test_list_jobs_dict`).

I have not run the `nox` backward-compatibility sessions (`stable_version_without_post_migration`) locally — CI covers those, and since this adds only a nullable column with no post-migration, I expect them to be unaffected.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation — `Job.deferred_at` carries a `#:` docstring and is picked up by the existing autodoc in `docs/reference.rst`; no prose docs seemed to need changing, but point me at anything I missed.
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->
  - [ ] <!-- Breaking -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
  - [x] <!-- Feature -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
  - [ ] <!-- Bugfix -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
  - [ ] <!-- Misc. -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
  - [ ] <!-- Deps -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
  - [ ] <!-- Docs -->https://github.com/procrastinate-org/procrastinate/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deferred jobs now record the timestamp when deferral occurs.
  - Job details, listings, logs, and integrations expose the new deferral timestamp.
  - Existing jobs remain compatible with a nullable timestamp.

- **Bug Fixes**
  - Job retrieval and monitoring now preserve deferral timing consistently across supported storage and integrations.

- **Tests**
  - Added coverage validating deferral timestamps across job management, task execution, CLI operations, in-memory storage, and Django integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->